### PR TITLE
Make evm depth visible

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -158,11 +158,6 @@ func (evm *EVM) Cancelled() bool {
 	return atomic.LoadInt32(&evm.abort) == 1
 }
 
-// Depth returns the current depth
-func (evm *EVM) Depth() int {
-	return evm.depth
-}
-
 // Interpreter returns the current interpreter
 func (evm *EVM) Interpreter() *EVMInterpreter {
 	return evm.interpreter

--- a/core/vm/evm_arbitrum.go
+++ b/core/vm/evm_arbitrum.go
@@ -1,0 +1,22 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+// Depth returns the current depth
+func (evm *EVM) Depth() int {
+	return evm.depth
+}


### PR DESCRIPTION
Add a public getter for the depth field of vm.EVM.  This is needed for ArbSys functionality.