### PR TITLE
Re-add file lock to freezer

### DIFF
--- a/core/rawdb/fileutil.go
+++ b/core/rawdb/fileutil.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !js
+// +build !js
+
+package rawdb
+
+import "github.com/prometheus/tsdb/fileutil"
+
+type Releaser interface {
+	Release() error
+}
+
+func Flock(fileName string) (r Releaser, existed bool, err error) {
+	return fileutil.Flock(fileName)
+}

--- a/core/rawdb/fileutil_mock.go
+++ b/core/rawdb/fileutil_mock.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build js
+// +build js
+
+package rawdb
+
+type Releaser interface {
+	Release() error
+}
+
+func Flock(fileName string) (r Releaser, existed bool, err error) {
+	return mockReleaser{}, false, nil
+}
+
+type mockReleaser struct{}
+
+func (r mockReleaser) Release() error {
+	return nil
+}


### PR DESCRIPTION
This both reduces the diff against upstream and adds back in a bit of safety. This was previously removed because it prevented building for WASM. This PR adds a mock that doesn't actually lock anything for the "js" target, but also has a real implementation for non-js targets.