### PR TITLE
Fix Arbitrum transaction type numbers

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -45,10 +45,10 @@ const (
 	LegacyTxType = iota
 	AccessListTxType
 	DynamicFeeTxType
-	ArbitrumDepositTxType  = 200
-	ArbitrumUnsignedTxType = 201
-	ArbitrumContractTxType = 202
-	ArbitrumWrappedTxType  = 203
+	ArbitrumDepositTxType  = 100
+	ArbitrumUnsignedTxType = 101
+	ArbitrumContractTxType = 102
+	ArbitrumWrappedTxType  = 103
 )
 
 // Transaction is an Ethereum transaction.


### PR DESCRIPTION
This moves the tx type numbers for Arbitrum transactions into the valid range (less than 128).  This range is required so that UnmarshalBinary will work.  UnmarshalBinary looks at the first byte of the binary format, and treats the tx as a LegacyTx if the first byte is >127, and as the tx type otherwise.  So the previous Arbitrum types would cause errors in unmarshaling from binary format.