### PR TITLE
Fix APIBackend geth interface implementation

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -92,6 +92,10 @@ func (a *APIBackend) RPCTxFeeCap() float64 {
 	return a.b.config.RPCTxFeeCap
 }
 
+func (a *APIBackend) RPCEVMTimeout() time.Duration {
+	return a.b.config.RPCEVMTimeout
+}
+
 func (a *APIBackend) UnprotectedAllowed() bool {
 	return true // TODO: is that true?
 }
@@ -179,7 +183,10 @@ func (a *APIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.R
 }
 
 func (a *APIBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
-	return a.blockChain().GetTdByHash(hash)
+	if header := a.blockChain().GetHeaderByHash(hash); header != nil {
+		return a.blockChain().GetTd(hash, header.Number.Uint64())
+	}
+	return nil
 }
 
 func (a *APIBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error) {

--- a/arbitrum/backend.go
+++ b/arbitrum/backend.go
@@ -2,6 +2,7 @@ package arbitrum
 
 import (
 	"context"
+	"time"
 
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,6 +33,9 @@ type Config struct {
 	// RPCTxFeeCap is the global transaction fee(price * gaslimit) cap for
 	// send-transction variants. The unit is ether.
 	RPCTxFeeCap float64
+
+	// RPCEVMTimeout is the global timeout for eth-call.
+	RPCEVMTimeout time.Duration
 }
 
 var DefaultConfig = Config{


### PR DESCRIPTION
As of latest master, APIBackend now doesn't correctly implement the api backend interface. This fixes that.