### PR TITLE
Add Type Field to ArbitrumInternalTx

### DIFF
--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -310,6 +310,7 @@ func (d *ArbitrumDepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
 
 type ArbitrumInternalTx struct {
 	ChainId     *big.Int
+	Type        uint8
 	Data        []byte
 	BlockNumber uint64
 	TxIndex     uint64
@@ -322,6 +323,7 @@ func (t *ArbitrumInternalTx) txType() byte {
 func (t *ArbitrumInternalTx) copy() TxData {
 	return &ArbitrumInternalTx{
 		new(big.Int).Set(t.ChainId),
+		t.Type,
 		common.CopyBytes(t.Data),
 		t.BlockNumber,
 		t.TxIndex,


### PR DESCRIPTION
Separates out what was the first byte of an `ArbitrumInternalTx` into its own `Type` field