### PR TITLE
Extend ArbitrumChainParams (part of Configurable chain configs)

### DIFF
--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -26,6 +26,7 @@ type ArbitrumChainParams struct {
 	EnableArbOS               bool
 	AllowDebugPrecompiles     bool
 	DataAvailabilityCommittee bool
+	InitialChainOwner         common.Address
 }
 
 func (c *ChainConfig) IsArbitrum() bool {
@@ -41,14 +42,26 @@ func ArbitrumOneParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
+		// Not used as arbitrum one has init data
+		InitialChainOwner: common.Address{},
 	}
 }
 
-func ArbitrumTestParams() ArbitrumChainParams {
+func ArbitrumTestnetParams() ArbitrumChainParams {
+	return ArbitrumChainParams{
+		EnableArbOS:               true,
+		AllowDebugPrecompiles:     false,
+		DataAvailabilityCommittee: false,
+		InitialChainOwner:         common.Address{}, // TODO
+	}
+}
+
+func ArbitrumDevTestParams() ArbitrumChainParams {
 	return ArbitrumChainParams{
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: false,
+		InitialChainOwner:         common.Address{},
 	}
 }
 
@@ -57,6 +70,7 @@ func DisableArbitrumParams() ArbitrumChainParams {
 		EnableArbOS:               false,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
+		InitialChainOwner:         common.Address{},
 	}
 }
 
@@ -85,7 +99,32 @@ func ArbitrumOneChainConfig() *ChainConfig {
 	}
 }
 
-func ArbitrumTestChainConfig() *ChainConfig {
+func ArbitrumTestnetChainConfig() *ChainConfig {
+	return &ChainConfig{
+		ChainID:             big.NewInt(421612),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ArbitrumChainParams: ArbitrumTestnetParams(),
+		Clique: &CliqueConfig{
+			Period: 0,
+			Epoch:  0,
+		},
+	}
+}
+
+func ArbitrumDevTestChainConfig() *ChainConfig {
 	return &ChainConfig{
 		ChainID:             big.NewInt(412345),
 		HomesteadBlock:      big.NewInt(0),
@@ -102,10 +141,16 @@ func ArbitrumTestChainConfig() *ChainConfig {
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
-		ArbitrumChainParams: ArbitrumTestParams(),
+		ArbitrumChainParams: ArbitrumDevTestParams(),
 		Clique: &CliqueConfig{
 			Period: 0,
 			Epoch:  0,
 		},
 	}
+}
+
+var ArbitrumSupportedChainConfigs = []*ChainConfig{
+	ArbitrumOneChainConfig(),
+	ArbitrumTestnetChainConfig(),
+	ArbitrumDevTestChainConfig(),
 }


### PR DESCRIPTION
Required by https://github.com/OffchainLabs/nitro/pull/311