### PR TITLE
Reduce initial basefee to 0.1 gwei

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -119,9 +119,9 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominator = 8          // Bounds the amount the base fee can change between blocks.
-	ElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
-	InitialBaseFee           = 1000000000 // Initial base fee for EIP-1559 blocks.
+	BaseFeeChangeDenominator = 8         // Bounds the amount the base fee can change between blocks.
+	ElasticityMultiplier     = 2         // Bounds the maximum gas limit an EIP-1559 block may have.
+	InitialBaseFee           = 100000000 // Initial base fee for EIP-1559 blocks = 0.1 GWei.
 
 	MaxCodeSize = 24576 // Maximum bytecode to permit for a contract
 


### PR DESCRIPTION
This reduces the initial basefee from 1 gwei to 0.1 gwei.

This will break tests in Nitro unless the corresponding Nitro PR is also merged.