### PR TITLE
Support `eth_feeHistory`

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -129,6 +129,9 @@ func (a *APIBackend) FeeHistory(
 	for i := range rewards {
 		rewards[i] = zeros
 	}
+	if len(rewardPercentiles) == 0 {
+		rewards = nil
+	}
 
 	gasUsed := make([]float64, blocks)
 	basefees := make([]*big.Int, blocks+1) // the RPC semantics are to predict the future value

--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -96,12 +96,16 @@ func (a *APIBackend) FeeHistory(
 		return nil, nil, nil, nil, errors.New("ArbOS not installed")
 	}
 
+	nitroGenesis := core.NitroGenesisBlock
 	latestBlock := rpc.BlockNumber(a.CurrentBlock().NumberU64())
 	if newestBlock == rpc.LatestBlockNumber || newestBlock == rpc.PendingBlockNumber {
 		newestBlock = latestBlock
 	}
 	if newestBlock > latestBlock {
 		newestBlock = latestBlock
+	}
+	if newestBlock < nitroGenesis {
+		newestBlock = nitroGenesis
 	}
 
 	maxFeeHistory := int(a.b.config.FeeHistoryMaxBlockCount)
@@ -115,8 +119,8 @@ func (a *APIBackend) FeeHistory(
 	}
 
 	// don't attempt to include blocks before genesis
-	if rpc.BlockNumber(blocks) > newestBlock {
-		blocks = int(newestBlock + 1)
+	if rpc.BlockNumber(blocks) > (newestBlock - nitroGenesis) {
+		blocks = int(newestBlock - nitroGenesis + 1)
 	}
 	oldestBlock := int(newestBlock) + 1 - blocks
 

--- a/arbitrum/config.go
+++ b/arbitrum/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Parameters for the bloom indexer
 	BloomBitsBlocks uint64 `koanf:"bloom-bits-blocks"`
 	BloomConfirms   uint64 `koanf:"bloom-confirms"`
+
+	// FeeHistoryMaxBlockCount limits the number of historical blocks a fee history request may cover
+	FeeHistoryMaxBlockCount uint64 `koanf:"feehistory-max-block-count"`
 }
 
 func ConfigAddOptions(prefix string, f *flag.FlagSet) {
@@ -29,13 +32,14 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.Float64(prefix+".tx-fee-cap", DefaultConfig.RPCTxFeeCap, "cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)")
 	f.Duration(prefix+".evm-timeout", DefaultConfig.RPCEVMTimeout, "timeout used for eth_call (0=infinite)")
 	f.Uint64(prefix+".bloom-bits-blocks", DefaultConfig.BloomBitsBlocks, "number of blocks a single bloom bit section vector holds")
-	f.Uint64(prefix+".bloom-confirms", DefaultConfig.BloomConfirms, "number of confirmations before indexing new bloom filters")
+	f.Uint64(prefix+".feehistory-max-block-count", DefaultConfig.FeeHistoryMaxBlockCount, "max number of blocks a fee history request may cover")
 }
 
 var DefaultConfig = Config{
-	RPCGasCap:       ethconfig.Defaults.RPCGasCap,     // 50,000,000
-	RPCTxFeeCap:     ethconfig.Defaults.RPCTxFeeCap,   // 1 ether
-	RPCEVMTimeout:   ethconfig.Defaults.RPCEVMTimeout, // 5 seconds
-	BloomBitsBlocks: params.BloomBitsBlocks * 4,       // we generally have smaller blocks
-	BloomConfirms:   params.BloomConfirms,
+	RPCGasCap:               ethconfig.Defaults.RPCGasCap,     // 50,000,000
+	RPCTxFeeCap:             ethconfig.Defaults.RPCTxFeeCap,   // 1 ether
+	RPCEVMTimeout:           ethconfig.Defaults.RPCEVMTimeout, // 5 seconds
+	BloomBitsBlocks:         params.BloomBitsBlocks * 4,       // we generally have smaller blocks
+	BloomConfirms:           params.BloomConfirms,
+	FeeHistoryMaxBlockCount: 1024,
 }

--- a/core/arbitrum_hooks.go
+++ b/core/arbitrum_hooks.go
@@ -37,6 +37,9 @@ var InterceptRPCMessage func(
 	backend NodeInterfaceBackendAPI,
 ) (types.Message, *ExecutionResult, error)
 
+// Gets ArbOS's approximation of how quickly compute gas is being burnt relative to the speed limit
+var GetArbOSComputeRate func(statedb *state.StateDB) (float64, error)
+
 // Allows ArbOS to update the gas cap so that it ignores the message's specific L1 poster costs.
 var InterceptRPCGasCap func(gascap *uint64, msg types.Message, header *types.Header, statedb *state.StateDB)
 

--- a/core/arbitrum_hooks.go
+++ b/core/arbitrum_hooks.go
@@ -37,8 +37,11 @@ var InterceptRPCMessage func(
 	backend NodeInterfaceBackendAPI,
 ) (types.Message, *ExecutionResult, error)
 
-// Gets ArbOS's approximation of how quickly compute gas is being burnt relative to the speed limit
+// Gets ArbOS's approximation of how quickly compute gas is being burnt relative to the speed limit.
 var GetArbOSComputeRate func(statedb *state.StateDB) (float64, error)
+
+// The Nitro genesis block. All blocks before this were imported.
+var NitroGenesisBlock rpc.BlockNumber
 
 // Allows ArbOS to update the gas cap so that it ignores the message's specific L1 poster costs.
 var InterceptRPCGasCap func(gascap *uint64, msg types.Message, header *types.Header, statedb *state.StateDB)


### PR DESCRIPTION
Supports `eth_feeHistory` by providing an output with similar semantic meaning & shape to the vanilla rpc call