### PR TITLE
L1RequestId missing from copy

### DIFF
--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -312,9 +312,10 @@ func (d *ArbitrumDepositTx) txType() byte {
 
 func (d *ArbitrumDepositTx) copy() TxData {
 	tx := &ArbitrumDepositTx{
-		ChainId: new(big.Int),
-		To:      d.To,
-		Value:   new(big.Int),
+		ChainId:     new(big.Int),
+		L1RequestId: d.L1RequestId,
+		To:          d.To,
+		Value:       new(big.Int),
 	}
 	if d.ChainId != nil {
 		tx.ChainId.Set(d.ChainId)


### PR DESCRIPTION
This meant we were losing the L1RequestId which, apart from other thing, was affecting the tx hash.