### PR TITLE
Export `DoEstimateGas`

### DIFF
--- a/arbitrum/export.go
+++ b/arbitrum/export.go
@@ -1,0 +1,15 @@
+package arbitrum
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type TransactionArgs = ethapi.TransactionArgs
+
+func EstimateGas(ctx context.Context, b ethapi.Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, gasCap uint64) (hexutil.Uint64, error) {
+	return ethapi.DoEstimateGas(ctx, b, args, blockNrOrHash, gasCap)
+}


### PR DESCRIPTION
Adds `exports.go`, a file for exposing content from internal packages.

This PR uses this to expose `DoEstimateGas`