### PR TITLE
support arbitrum-legacy state import

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -96,8 +96,8 @@ func (a *APIBackend) FeeHistory(
 		return nil, nil, nil, nil, errors.New("ArbOS not installed")
 	}
 
-	nitroGenesis := core.NitroGenesisBlock
-	newestBlock, latestBlock := ClipToPostNitroGenesis(a, newestBlock)
+	nitroGenesis := rpc.BlockNumber(a.ChainConfig().ArbitrumChainParams.GenesisBlockNum)
+	newestBlock, latestBlock := a.blockChain().ClipToPostNitroGenesis(a, newestBlock)
 
 	maxFeeHistory := int(a.b.config.FeeHistoryMaxBlockCount)
 	if blocks > maxFeeHistory {
@@ -415,22 +415,4 @@ func (a *APIBackend) ChainConfig() *params.ChainConfig {
 
 func (a *APIBackend) Engine() consensus.Engine {
 	return a.blockChain().Engine()
-}
-
-type GetsCurrentBlock interface {
-	CurrentBlock() *types.Block
-}
-
-func ClipToPostNitroGenesis(getter GetsCurrentBlock, blockNum rpc.BlockNumber) (rpc.BlockNumber, rpc.BlockNumber) {
-	currentBlock := rpc.BlockNumber(getter.CurrentBlock().NumberU64())
-	if blockNum == rpc.LatestBlockNumber || blockNum == rpc.PendingBlockNumber {
-		blockNum = currentBlock
-	}
-	if blockNum > currentBlock {
-		blockNum = currentBlock
-	}
-	if blockNum < core.NitroGenesisBlock {
-		blockNum = core.NitroGenesisBlock
-	}
-	return blockNum, currentBlock
 }

--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -97,7 +97,7 @@ func (a *APIBackend) FeeHistory(
 	}
 
 	nitroGenesis := rpc.BlockNumber(a.ChainConfig().ArbitrumChainParams.GenesisBlockNum)
-	newestBlock, latestBlock := a.blockChain().ClipToPostNitroGenesis(a, newestBlock)
+	newestBlock, latestBlock := a.blockChain().ClipToPostNitroGenesis(newestBlock)
 
 	maxFeeHistory := int(a.b.config.FeeHistoryMaxBlockCount)
 	if blocks > maxFeeHistory {

--- a/core/arbitrum_hooks.go
+++ b/core/arbitrum_hooks.go
@@ -41,9 +41,6 @@ var InterceptRPCMessage func(
 // Gets ArbOS's approximation of how quickly compute gas is being burnt relative to the speed limit.
 var GetArbOSComputeRate func(statedb *state.StateDB) (float64, error)
 
-// The Nitro genesis block. All blocks before this were imported.
-var NitroGenesisBlock rpc.BlockNumber
-
 // Allows ArbOS to update the gas cap so that it ignores the message's specific L1 poster costs.
 var InterceptRPCGasCap func(gascap *uint64, msg types.Message, header *types.Header, statedb *state.StateDB)
 

--- a/core/blockchain_arbitrum.go
+++ b/core/blockchain_arbitrum.go
@@ -44,8 +44,8 @@ type GetsCurrentBlock interface {
 	CurrentBlock() *types.Block
 }
 
-func (bc *BlockChain) ClipToPostNitroGenesis(getter GetsCurrentBlock, blockNum rpc.BlockNumber) (rpc.BlockNumber, rpc.BlockNumber) {
-	currentBlock := rpc.BlockNumber(getter.CurrentBlock().NumberU64())
+func (bc *BlockChain) ClipToPostNitroGenesis(blockNum rpc.BlockNumber) (rpc.BlockNumber, rpc.BlockNumber) {
+	currentBlock := rpc.BlockNumber(bc.CurrentBlock().NumberU64())
 	nitroGenesis := rpc.BlockNumber(bc.Config().ArbitrumChainParams.GenesisBlockNum)
 	if blockNum == rpc.LatestBlockNumber || blockNum == rpc.PendingBlockNumber {
 		blockNum = currentBlock

--- a/core/blockchain_arbitrum.go
+++ b/core/blockchain_arbitrum.go
@@ -40,10 +40,6 @@ func (bc *BlockChain) ReorgToOldBlock(newHead *types.Block) error {
 	return nil
 }
 
-type GetsCurrentBlock interface {
-	CurrentBlock() *types.Block
-}
-
 func (bc *BlockChain) ClipToPostNitroGenesis(blockNum rpc.BlockNumber) (rpc.BlockNumber, rpc.BlockNumber) {
 	currentBlock := rpc.BlockNumber(bc.CurrentBlock().NumberU64())
 	nitroGenesis := rpc.BlockNumber(bc.Config().ArbitrumChainParams.GenesisBlockNum)

--- a/core/types/arbitrum_legacy_tx.go
+++ b/core/types/arbitrum_legacy_tx.go
@@ -10,17 +10,21 @@ import (
 
 type ArbitrumLegacyTxData struct {
 	LegacyTx
-	HashOverride common.Hash // Hash cannot be locally computed from other fields
+	HashOverride      common.Hash // Hash cannot be locally computed from other fields
+	EffectiveGasPrice uint64
+	L1BlockNumber     uint64
 }
 
-func NewArbitrumLegacyTx(origTx *Transaction, hashOverride common.Hash) (*Transaction, error) {
+func NewArbitrumLegacyTx(origTx *Transaction, hashOverride common.Hash, effectiveGas uint64, l1Block uint64) (*Transaction, error) {
 	if origTx.Type() != LegacyTxType {
 		return nil, errors.New("attempt to arbitrum-wrap non-legacy transaction")
 	}
-	legacyCopy := origTx.GetInner().(*LegacyTx)
+	legacyPtr := origTx.GetInner().(*LegacyTx)
 	inner := ArbitrumLegacyTxData{
-		LegacyTx:     *legacyCopy,
-		HashOverride: hashOverride,
+		LegacyTx:          *legacyPtr,
+		HashOverride:      hashOverride,
+		EffectiveGasPrice: effectiveGas,
+		L1BlockNumber:     l1Block,
 	}
 	return NewTx(&inner), nil
 }
@@ -28,8 +32,10 @@ func NewArbitrumLegacyTx(origTx *Transaction, hashOverride common.Hash) (*Transa
 func (tx *ArbitrumLegacyTxData) copy() TxData {
 	legacyCopy := tx.LegacyTx.copy().(*LegacyTx)
 	return &ArbitrumLegacyTxData{
-		LegacyTx:     *legacyCopy,
-		HashOverride: tx.HashOverride,
+		LegacyTx:          *legacyCopy,
+		HashOverride:      tx.HashOverride,
+		EffectiveGasPrice: tx.EffectiveGasPrice,
+		L1BlockNumber:     tx.L1BlockNumber,
 	}
 }
 

--- a/core/types/arbitrum_legacy_tx.go
+++ b/core/types/arbitrum_legacy_tx.go
@@ -1,126 +1,40 @@
 package types
 
 import (
-	"math/big"
+	"bytes"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
-// Data as received from Arb1 chain
-type ArbitrumLegacyTransactionResult struct {
-	BlockHash        *common.Hash    `json:"blockHash"`
-	BlockNumber      *hexutil.Big    `json:"blockNumber"`
-	From             common.Address  `json:"from"`
-	Gas              hexutil.Uint64  `json:"gas"`
-	GasPrice         *hexutil.Big    `json:"gasPrice"`
-	Hash             common.Hash     `json:"hash"`
-	Input            hexutil.Bytes   `json:"input"`
-	Nonce            hexutil.Uint64  `json:"nonce"`
-	To               *common.Address `json:"to"`
-	TransactionIndex *hexutil.Uint64 `json:"transactionIndex"`
-	Value            *hexutil.Big    `json:"value"`
-	V                *hexutil.Big    `json:"v"`
-	R                *hexutil.Big    `json:"r"`
-	S                *hexutil.Big    `json:"s"`
-
-	// Arbitrum Specific Fields
-	L1SeqNum        *hexutil.Big    `json:"l1SequenceNumber"`
-	ParentRequestId *common.Hash    `json:"parentRequestId"`
-	IndexInParent   *hexutil.Big    `json:"indexInParent"`
-	ArbType         hexutil.Uint64  `json:"arbType"`
-	ArbSubType      *hexutil.Uint64 `json:"arbSubType"`
-	L1BlockNumber   *hexutil.Big    `json:"l1BlockNumber"`
+type ArbitrumLegacyTxData struct {
+	LegacyTx
+	HashOverride common.Hash // Hash cannot be locally computed from other fields
 }
 
-type ArbitrumLegacyTxData struct {
-	Gas      uint64
-	GasPrice *big.Int
-	Hash     common.Hash // Hash cannot be locally computed from other fields
-	Data     []byte
-	Nonce    uint64
-	To       *common.Address `rlp:"nil"` // nil means contract creation
-	Value    *big.Int
-	V, R, S  *big.Int
+func NewArbitrumLegacyTx(origTx *Transaction, hashOverride common.Hash) (*Transaction, error) {
+	if origTx.Type() != LegacyTxType {
+		return nil, errors.New("attempt to arbitrum-wrap non-legacy transaction")
+	}
+	legacyCopy := origTx.GetInner().(*LegacyTx)
+	inner := ArbitrumLegacyTxData{
+		LegacyTx:     *legacyCopy,
+		HashOverride: hashOverride,
+	}
+	return NewTx(&inner), nil
 }
 
 func (tx *ArbitrumLegacyTxData) copy() TxData {
-	cpy := &ArbitrumLegacyTxData{
-		Nonce: tx.Nonce,
-		To:    copyAddressPtr(tx.To),
-		Data:  common.CopyBytes(tx.Data),
-		Gas:   tx.Gas,
-		Hash:  tx.Hash,
-		// These are initialized below.
-		Value:    new(big.Int),
-		GasPrice: new(big.Int),
-		V:        new(big.Int),
-		R:        new(big.Int),
-		S:        new(big.Int),
+	legacyCopy := tx.LegacyTx.copy().(*LegacyTx)
+	return &ArbitrumLegacyTxData{
+		LegacyTx:     *legacyCopy,
+		HashOverride: tx.HashOverride,
 	}
-	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
-	}
-	if tx.GasPrice != nil {
-		cpy.GasPrice.Set(tx.GasPrice)
-	}
-	if tx.V != nil {
-		cpy.V.Set(tx.V)
-	}
-	if tx.R != nil {
-		cpy.R.Set(tx.R)
-	}
-	if tx.S != nil {
-		cpy.S.Set(tx.S)
-	}
-	return cpy
 }
 
-func ArbitrumLegacyFromTransactionResult(result ArbitrumLegacyTransactionResult) *Transaction {
-	gas := uint64(result.Gas)
-	nonce := uint64(result.Nonce)
-	gasPrice := (*big.Int)(result.GasPrice)
-	value := (*big.Int)(result.Value)
-	v := (*big.Int)(result.V)
-	r := (*big.Int)(result.R)
-	s := (*big.Int)(result.S)
-	hash := common.Hash(result.Hash)
-	to := copyAddressPtr(result.To)
-	var data []byte = result.Input
-	arblegacy := ArbitrumLegacyTxData{
-		Gas:      gas,
-		GasPrice: gasPrice,
-		Hash:     hash,
-		Data:     data,
-		Nonce:    nonce,
-		To:       to,
-		Value:    value,
-		V:        v,
-		R:        r,
-		S:        s,
-	}
-	return NewTx(&arblegacy)
-}
+func (tx *ArbitrumLegacyTxData) txType() byte { return ArbitrumLegacyTxType }
 
-// accessors for innerTx.
-func (tx *ArbitrumLegacyTxData) txType() byte           { return ArbitrumLegacyTxType }
-func (tx *ArbitrumLegacyTxData) chainID() *big.Int      { return deriveChainId(tx.V) }
-func (tx *ArbitrumLegacyTxData) accessList() AccessList { return nil }
-func (tx *ArbitrumLegacyTxData) data() []byte           { return tx.Data }
-func (tx *ArbitrumLegacyTxData) gas() uint64            { return tx.Gas }
-func (tx *ArbitrumLegacyTxData) gasPrice() *big.Int     { return tx.GasPrice }
-func (tx *ArbitrumLegacyTxData) gasTipCap() *big.Int    { return tx.GasPrice }
-func (tx *ArbitrumLegacyTxData) gasFeeCap() *big.Int    { return tx.GasPrice }
-func (tx *ArbitrumLegacyTxData) value() *big.Int        { return tx.Value }
-func (tx *ArbitrumLegacyTxData) nonce() uint64          { return tx.Nonce }
-func (tx *ArbitrumLegacyTxData) to() *common.Address    { return tx.To }
-
-func (tx *ArbitrumLegacyTxData) isFake() bool { return false }
-
-func (tx *ArbitrumLegacyTxData) rawSignatureValues() (v, r, s *big.Int) {
-	return tx.V, tx.R, tx.S
-}
-
-func (tx *ArbitrumLegacyTxData) setSignatureValues(chainID, v, r, s *big.Int) {
-	tx.V, tx.R, tx.S = v, r, s
+func (tx *ArbitrumLegacyTxData) EncodeOnlyLegacyInto(w *bytes.Buffer) {
+	rlp.Encode(w, tx.LegacyTx)
 }

--- a/core/types/arbitrum_signer.go
+++ b/core/types/arbitrum_signer.go
@@ -32,6 +32,10 @@ func (s arbitrumSigner) Sender(tx *Transaction) (common.Address, error) {
 		return inner.From, nil
 	case *ArbitrumSubmitRetryableTx:
 		return inner.From, nil
+	case *ArbitrumLegacyTxData:
+		legacyData := tx.inner.(*ArbitrumLegacyTxData)
+		fakeTx := NewTx(&legacyData.LegacyTx)
+		return s.Signer.Sender(fakeTx)
 	default:
 		return s.Signer.Sender(tx)
 	}
@@ -56,6 +60,10 @@ func (s arbitrumSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *b
 		return bigZero, bigZero, bigZero, nil
 	case *ArbitrumSubmitRetryableTx:
 		return bigZero, bigZero, bigZero, nil
+	case *ArbitrumLegacyTxData:
+		legacyData := tx.inner.(*ArbitrumLegacyTxData)
+		fakeTx := NewTx(&legacyData.LegacyTx)
+		return s.Signer.SignatureValues(fakeTx, sig)
 	default:
 		return s.Signer.SignatureValues(tx, sig)
 	}
@@ -64,5 +72,9 @@ func (s arbitrumSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *b
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s arbitrumSigner) Hash(tx *Transaction) common.Hash {
+	if legacyData, isArbLegacy := tx.inner.(*ArbitrumLegacyTxData); isArbLegacy {
+		fakeTx := NewTx(&legacyData.LegacyTx)
+		return s.Signer.Hash(fakeTx)
+	}
 	return s.Signer.Hash(tx)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -415,7 +415,7 @@ func (tx *Transaction) Hash() common.Hash {
 	if tx.Type() == LegacyTxType {
 		h = rlpHash(tx.inner)
 	} else if tx.Type() == ArbitrumLegacyTxType {
-		h = tx.inner.(*ArbitrumLegacyTxData).Hash
+		h = tx.inner.(*ArbitrumLegacyTxData).HashOverride
 	} else {
 		h = prefixedRlpHash(tx.Type(), tx.inner)
 	}
@@ -460,6 +460,9 @@ func (s Transactions) EncodeIndex(i int, w *bytes.Buffer) {
 	tx := s[i]
 	if tx.Type() == LegacyTxType {
 		rlp.Encode(w, tx.inner)
+	} else if tx.Type() == ArbitrumLegacyTxType {
+		arbData := tx.inner.(*ArbitrumLegacyTxData)
+		arbData.EncodeOnlyLegacyInto(w)
 	} else {
 		tx.encodeTyped(w)
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -472,6 +472,9 @@ func (c *ChainConfig) IsBerlin(num *big.Int) bool {
 
 // IsLondon returns whether num is either equal to the London fork block or greater.
 func (c *ChainConfig) IsLondon(num *big.Int) bool {
+	if c.IsArbitrum() {
+		return isForked(new(big.Int).SetUint64(c.ArbitrumChainParams.GenesisBlockNum), num)
+	}
 	return isForked(c.LondonBlock, num)
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -605,7 +605,7 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.MergeForkBlock, newcfg.MergeForkBlock, head) {
 		return newCompatError("Merge Start fork block", c.MergeForkBlock, newcfg.MergeForkBlock)
 	}
-	return nil
+	return c.checkArbitrumCompatible(newcfg, head)
 }
 
 // isForkIncompatible returns true if a fork scheduled at s1 cannot be rescheduled to

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -247,10 +247,36 @@ func ArbitrumDevnetDASChainConfig() *ChainConfig {
 	}
 }
 
+func ArbitrumRinkebyDevTestChainConfig() *ChainConfig {
+	return &ChainConfig{
+		ChainID:             big.NewInt(421611),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ArbitrumChainParams: ArbitrumDevTestParams(),
+		Clique: &CliqueConfig{
+			Period: 0,
+			Epoch:  0,
+		},
+	}
+}
+
 var ArbitrumSupportedChainConfigs = []*ChainConfig{
 	ArbitrumOneChainConfig(),
 	ArbitrumTestnetChainConfig(),
 	ArbitrumDevTestChainConfig(),
 	ArbitrumDevTestDASChainConfig(),
 	ArbitrumDevnetDASChainConfig(),
+	ArbitrumRinkebyDevTestChainConfig(),
 }

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -28,6 +28,7 @@ type ArbitrumChainParams struct {
 	DataAvailabilityCommittee bool
 	InitialArbOSVersion       uint64
 	InitialChainOwner         common.Address
+	GenesisBlockNum           uint64
 }
 
 func (c *ChainConfig) IsArbitrum() bool {
@@ -36,6 +37,28 @@ func (c *ChainConfig) IsArbitrum() bool {
 
 func (c *ChainConfig) DebugMode() bool {
 	return c.ArbitrumChainParams.AllowDebugPrecompiles
+}
+
+func (c *ChainConfig) checkArbitrumCompatible(newcfg *ChainConfig, head *big.Int) *ConfigCompatError {
+	boolToBig := func(b bool) *big.Int {
+		if b {
+			return common.Big1
+		}
+		return common.Big0
+	}
+
+	if c.IsArbitrum() != newcfg.IsArbitrum() {
+		return newCompatError("isArbitrum", boolToBig(c.IsArbitrum()), boolToBig(newcfg.IsArbitrum()))
+	}
+	if !c.IsArbitrum() {
+		return nil
+	}
+	cArb := &c.ArbitrumChainParams
+	newArb := &newcfg.ArbitrumChainParams
+	if cArb.GenesisBlockNum != newArb.GenesisBlockNum {
+		return newCompatError("genesisblocknum", new(big.Int).SetUint64(cArb.GenesisBlockNum), new(big.Int).SetUint64(newArb.GenesisBlockNum))
+	}
+	return nil
 }
 
 func ArbitrumOneParams() ArbitrumChainParams {


### PR DESCRIPTION
Mostly Tsahi's work, but I made it a PR. This PR updates geth to rely on the `genesisBlockNumber` chain param rather than global state