### PR TITLE
Improve Arbitrum config compat errors

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -574,6 +574,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if c.IsEIP158(head) && !configNumEqual(c.ChainID, newcfg.ChainID) {
 		return newCompatError("EIP158 chain ID", c.EIP158Block, newcfg.EIP158Block)
 	}
+	if err := c.checkArbitrumCompatible(newcfg, head); err != nil {
+		return err
+	}
 	if isForkIncompatible(c.ByzantiumBlock, newcfg.ByzantiumBlock, head) {
 		return newCompatError("Byzantium fork block", c.ByzantiumBlock, newcfg.ByzantiumBlock)
 	}
@@ -605,7 +608,7 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.MergeForkBlock, newcfg.MergeForkBlock, head) {
 		return newCompatError("Merge Start fork block", c.MergeForkBlock, newcfg.MergeForkBlock)
 	}
-	return c.checkArbitrumCompatible(newcfg, head)
+	return nil
 }
 
 // isForkIncompatible returns true if a fork scheduled at s1 cannot be rescheduled to

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -40,15 +40,9 @@ func (c *ChainConfig) DebugMode() bool {
 }
 
 func (c *ChainConfig) checkArbitrumCompatible(newcfg *ChainConfig, head *big.Int) *ConfigCompatError {
-	boolToBig := func(b bool) *big.Int {
-		if b {
-			return common.Big1
-		}
-		return common.Big0
-	}
-
 	if c.IsArbitrum() != newcfg.IsArbitrum() {
-		return newCompatError("isArbitrum", boolToBig(c.IsArbitrum()), boolToBig(newcfg.IsArbitrum()))
+		// This difference applies to the entire chain, so report that the genesis block is where the difference appears.
+		return newCompatError("isArbitrum", common.Big0, common.Big0)
 	}
 	if !c.IsArbitrum() {
 		return nil


### PR DESCRIPTION
- Moves the `checkArbitrumCompatible` to earlier in the function to avoid merge conflicts
- Returns block 0 as the divergence when one chain has Arbitrum enabled and the other doesn't