### PR TITLE
`RetryValue` field

### DIFF
--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -216,7 +216,7 @@ type ArbitrumSubmitRetryableTx struct {
 	GasFeeCap        *big.Int        // wei per gas
 	Gas              uint64          // gas limit
 	RetryTo          *common.Address `rlp:"nil"` // nil means contract creation
-	Value            *big.Int        // wei amount
+	RetryValue       *big.Int        // wei amount
 	Beneficiary      common.Address
 	MaxSubmissionFee *big.Int
 	FeeRefundAddr    common.Address
@@ -235,7 +235,7 @@ func (tx *ArbitrumSubmitRetryableTx) copy() TxData {
 		Gas:              tx.Gas,
 		From:             tx.From,
 		RetryTo:          tx.RetryTo,
-		Value:            new(big.Int),
+		RetryValue:       new(big.Int),
 		Beneficiary:      tx.Beneficiary,
 		MaxSubmissionFee: new(big.Int),
 		FeeRefundAddr:    tx.FeeRefundAddr,
@@ -257,8 +257,8 @@ func (tx *ArbitrumSubmitRetryableTx) copy() TxData {
 		tmp := *tx.RetryTo
 		cpy.RetryTo = &tmp
 	}
-	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
+	if tx.RetryValue != nil {
+		cpy.RetryValue.Set(tx.RetryValue)
 	}
 	if tx.MaxSubmissionFee != nil {
 		cpy.MaxSubmissionFee.Set(tx.MaxSubmissionFee)
@@ -272,7 +272,7 @@ func (tx *ArbitrumSubmitRetryableTx) gas() uint64            { return tx.Gas }
 func (tx *ArbitrumSubmitRetryableTx) gasPrice() *big.Int     { return tx.GasFeeCap }
 func (tx *ArbitrumSubmitRetryableTx) gasTipCap() *big.Int    { return big.NewInt(0) }
 func (tx *ArbitrumSubmitRetryableTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
-func (tx *ArbitrumSubmitRetryableTx) value() *big.Int        { return tx.Value }
+func (tx *ArbitrumSubmitRetryableTx) value() *big.Int        { return common.Big0 }
 func (tx *ArbitrumSubmitRetryableTx) nonce() uint64          { return 0 }
 func (tx *ArbitrumSubmitRetryableTx) to() *common.Address    { return &ArbRetryableTxAddress }
 func (tx *ArbitrumSubmitRetryableTx) rawSignatureValues() (v, r, s *big.Int) {
@@ -290,7 +290,7 @@ func (tx *ArbitrumSubmitRetryableTx) data() []byte {
 	data = append(data, tx.RequestId.Bytes()...)
 	data = append(data, math.U256Bytes(tx.L1BaseFee)...)
 	data = append(data, math.U256Bytes(tx.DepositValue)...)
-	data = append(data, math.U256Bytes(tx.Value)...)
+	data = append(data, math.U256Bytes(tx.RetryValue)...)
 	data = append(data, math.U256Bytes(tx.GasFeeCap)...)
 	data = append(data, math.U256Bytes(new(big.Int).SetUint64(tx.Gas))...)
 	data = append(data, math.U256Bytes(tx.MaxSubmissionFee)...)

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -56,6 +56,7 @@ type txJSON struct {
 	L1BaseFee           *hexutil.Big    `json:"l1BaseFee,omitempty"`           // SubmitRetryable
 	DepositValue        *hexutil.Big    `json:"depositValue,omitempty"`        // SubmitRetryable
 	RetryTo             *common.Address `json:"retryTo,omitempty"`             // SubmitRetryable
+	RetryValue          *hexutil.Big    `json:"retryValue,omitempty"`          // SubmitRetryable
 	RetryData           *hexutil.Bytes  `json:"retryData,omitempty"`           // SubmitRetryable
 	Beneficiary         *common.Address `json:"beneficiary,omitempty"`         // SubmitRetryable
 	MaxSubmissionFee    *hexutil.Big    `json:"maxSubmissionFee,omitempty"`    // SubmitRetryable
@@ -180,8 +181,8 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		enc.Gas = (*hexutil.Uint64)(&tx.Gas)
 		enc.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap)
 		enc.RetryTo = tx.RetryTo
+		enc.RetryValue = (*hexutil.Big)(tx.RetryValue)
 		enc.RetryData = (*hexutil.Bytes)(&tx.RetryData)
-		enc.Value = (*hexutil.Big)(tx.Value)
 		data := tx.data()
 		enc.Data = (*hexutil.Bytes)(&data)
 		enc.To = t.To()
@@ -564,9 +565,6 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.RetryTo == nil {
 			return errors.New("missing required field 'retryTo' in txdata")
 		}
-		if dec.Value == nil {
-			return errors.New("missing required field 'value' in transaction")
-		}
 		if dec.Beneficiary == nil {
 			return errors.New("missing required field 'beneficiary' in transaction")
 		}
@@ -575,6 +573,9 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 		}
 		if dec.RefundTo == nil {
 			return errors.New("missing required field 'refundTo' in transaction")
+		}
+		if dec.RetryValue == nil {
+			return errors.New("missing required field 'retryValue' in transaction")
 		}
 		if dec.RetryData == nil {
 			return errors.New("missing required field 'retryData' in transaction")
@@ -588,7 +589,7 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			GasFeeCap:        (*big.Int)(dec.MaxFeePerGas),
 			Gas:              uint64(*dec.Gas),
 			RetryTo:          dec.RetryTo,
-			Value:            (*big.Int)(dec.Value),
+			RetryValue:       (*big.Int)(dec.RetryValue),
 			Beneficiary:      *dec.Beneficiary,
 			MaxSubmissionFee: (*big.Int)(dec.MaxSubmissionFee),
 			FeeRefundAddr:    *dec.RefundTo,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1362,6 +1362,7 @@ type RPCTransaction struct {
 	L1BaseFee           *hexutil.Big    `json:"l1BaseFee,omitempty"`           // SubmitRetryable
 	DepositValue        *hexutil.Big    `json:"depositValue,omitempty"`        // SubmitRetryable
 	RetryTo             *common.Address `json:"retryTo,omitempty"`             // SubmitRetryable
+	RetryValue          *hexutil.Big    `json:"retryValue,omitempty"`          // SubmitRetryable
 	RetryData           *hexutil.Bytes  `json:"retryData,omitempty"`           // SubmitRetryable
 	Beneficiary         *common.Address `json:"beneficiary,omitempty"`         // SubmitRetryable
 	MaxSubmissionFee    *hexutil.Big    `json:"maxSubmissionFee,omitempty"`    // SubmitRetryable
@@ -1436,6 +1437,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.L1BaseFee = (*hexutil.Big)(inner.L1BaseFee)
 		result.DepositValue = (*hexutil.Big)(inner.DepositValue)
 		result.RetryTo = inner.RetryTo
+		result.RetryValue = (*hexutil.Big)(inner.RetryValue)
 		result.RetryData = (*hexutil.Bytes)(&inner.RetryData)
 		result.Beneficiary = &inner.Beneficiary
 		result.RefundTo = &inner.FeeRefundAddr


### PR DESCRIPTION
Renames `ArbitrumSubmitRetryableTx`'s `Value` to `RetryValue` and reports `0` for calls to `Value()`

This does not change consensus