### PR TITLE
Add hook for gasprice opcode

### DIFF
--- a/core/vm/evm_arbitrum.go
+++ b/core/vm/evm_arbitrum.go
@@ -17,6 +17,8 @@
 package vm
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -45,6 +47,7 @@ type TxProcessingHook interface {
 	ScheduledTxes() types.Transactions
 	L1BlockNumber(blockCtx BlockContext) (uint64, error)
 	L1BlockHash(blockCtx BlockContext, l1BlocKNumber uint64) (common.Hash, error)
+	GasPriceOp(evm *EVM) *big.Int
 	FillReceiptInfo(receipt *types.Receipt)
 }
 
@@ -83,6 +86,10 @@ func (p DefaultTxProcessor) L1BlockNumber(blockCtx BlockContext) (uint64, error)
 
 func (p DefaultTxProcessor) L1BlockHash(blockCtx BlockContext, l1BlocKNumber uint64) (common.Hash, error) {
 	return blockCtx.GetHash(l1BlocKNumber), nil
+}
+
+func (p DefaultTxProcessor) GasPriceOp(evm *EVM) *big.Int {
+	return evm.GasPrice
 }
 
 func (p DefaultTxProcessor) FillReceiptInfo(*types.Receipt) {}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -428,7 +428,11 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 }
 
 func opGasprice(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v, _ := uint256.FromBig(interpreter.evm.GasPrice)
+
+	// Arbitrum: provide an opportunity to remove the tip from the gas price
+	gasPrice := interpreter.evm.ProcessingHook.GasPriceOp(interpreter.evm)
+
+	v, _ := uint256.FromBig(gasPrice)
 	scope.Stack.push(v)
 	return nil, nil
 }


### PR DESCRIPTION
Adds a `GasPriceOp` hook so that ArbOS can cause this opcode to not include the tip in version 3