### PR TITLE
Use ArbOS version 3 in testing

### DIFF
--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -97,7 +97,7 @@ func ArbitrumDevTestParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       2,
+		InitialArbOSVersion:       3,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -107,7 +107,7 @@ func ArbitrumDevTestDASParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       2,
+		InitialArbOSVersion:       3,
 		InitialChainOwner:         common.Address{},
 	}
 }


### PR DESCRIPTION
This set ArbOS version to 3 in Nitro testing configurations.