### PR TITLE
arbdebug config options

### DIFF
--- a/arbitrum/config.go
+++ b/arbitrum/config.go
@@ -26,16 +26,51 @@ type Config struct {
 	// FeeHistoryMaxBlockCount limits the number of historical blocks a fee history request may cover
 	FeeHistoryMaxBlockCount uint64 `koanf:"feehistory-max-block-count"`
 
+	ArbDebug ArbDebugConfig `koanf:"arbdebug"`
+
 	ClassicRedirect string `koanf:"classic-redirect"`
 }
 
+type ArbDebugConfig struct {
+	BlockRangeBound   uint64 `koanf:"block-range-bound"`
+	TimeoutQueueBound uint64 `koanf:"timeout-queue-bound"`
+}
+
 func ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(prefix+".gas-cap", DefaultConfig.RPCGasCap, "cap on computation gas that can be used in eth_call/estimateGas (0=infinite)")
-	f.Float64(prefix+".tx-fee-cap", DefaultConfig.RPCTxFeeCap, "cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)")
-	f.Duration(prefix+".evm-timeout", DefaultConfig.RPCEVMTimeout, "timeout used for eth_call (0=infinite)")
-	f.Uint64(prefix+".bloom-bits-blocks", DefaultConfig.BloomBitsBlocks, "number of blocks a single bloom bit section vector holds")
-	f.Uint64(prefix+".feehistory-max-block-count", DefaultConfig.FeeHistoryMaxBlockCount, "max number of blocks a fee history request may cover")
-	f.String(prefix+".classic-redirect", DefaultConfig.ClassicRedirect, "url to redirect classic requests, use \"error:[CODE:]MESSAGE\" to return specified error instead of redirecting")
+	f.Uint64(
+		prefix+".gas-cap", DefaultConfig.RPCGasCap,
+		"cap on computation gas that can be used in eth_call/estimateGas (0=infinite)",
+	)
+	f.Float64(
+		prefix+".tx-fee-cap", DefaultConfig.RPCTxFeeCap,
+		"cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)",
+	)
+	f.Duration(
+		prefix+".evm-timeout", DefaultConfig.RPCEVMTimeout,
+		"timeout used for eth_call (0=infinite)",
+	)
+	f.Uint64(
+		prefix+".bloom-bits-blocks", DefaultConfig.BloomBitsBlocks,
+		"number of blocks a single bloom bit section vector holds",
+	)
+	f.Uint64(
+		prefix+".feehistory-max-block-count", DefaultConfig.FeeHistoryMaxBlockCount,
+		"max number of blocks a fee history request may cover",
+	)
+	f.String(
+		prefix+".classic-redirect", DefaultConfig.ClassicRedirect,
+		"url to redirect classic requests, use \"error:[CODE:]MESSAGE\" to return specified error instead of redirecting",
+	)
+
+	ArbDebug := DefaultConfig.ArbDebug
+	f.Uint64(
+		prefix+".arbdebug.block-range-bound", ArbDebug.BlockRangeBound,
+		"bounds the number of blocks arbdebug calls may return",
+	)
+	f.Uint64(
+		prefix+".arbdebug.timeout-queue-bound", ArbDebug.TimeoutQueueBound,
+		"bounds the length of timeout queues arbdebug calls may return",
+	)
 }
 
 var DefaultConfig = Config{
@@ -46,4 +81,8 @@ var DefaultConfig = Config{
 	BloomConfirms:           params.BloomConfirms,
 	FeeHistoryMaxBlockCount: 1024,
 	ClassicRedirect:         "",
+	ArbDebug: ArbDebugConfig{
+		BlockRangeBound:   1024,
+		TimeoutQueueBound: 1024,
+	},
 }

--- a/arbitrum/config.go
+++ b/arbitrum/config.go
@@ -62,13 +62,13 @@ func ConfigAddOptions(prefix string, f *flag.FlagSet) {
 		"url to redirect classic requests, use \"error:[CODE:]MESSAGE\" to return specified error instead of redirecting",
 	)
 
-	ArbDebug := DefaultConfig.ArbDebug
+	arbDebug := DefaultConfig.ArbDebug
 	f.Uint64(
-		prefix+".arbdebug.block-range-bound", ArbDebug.BlockRangeBound,
+		prefix+".arbdebug.block-range-bound", arbDebug.BlockRangeBound,
 		"bounds the number of blocks arbdebug calls may return",
 	)
 	f.Uint64(
-		prefix+".arbdebug.timeout-queue-bound", ArbDebug.TimeoutQueueBound,
+		prefix+".arbdebug.timeout-queue-bound", arbDebug.TimeoutQueueBound,
 		"bounds the length of timeout queues arbdebug calls may return",
 	)
 }

--- a/arbitrum/config.go
+++ b/arbitrum/config.go
@@ -37,40 +37,16 @@ type ArbDebugConfig struct {
 }
 
 func ConfigAddOptions(prefix string, f *flag.FlagSet) {
-	f.Uint64(
-		prefix+".gas-cap", DefaultConfig.RPCGasCap,
-		"cap on computation gas that can be used in eth_call/estimateGas (0=infinite)",
-	)
-	f.Float64(
-		prefix+".tx-fee-cap", DefaultConfig.RPCTxFeeCap,
-		"cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)",
-	)
-	f.Duration(
-		prefix+".evm-timeout", DefaultConfig.RPCEVMTimeout,
-		"timeout used for eth_call (0=infinite)",
-	)
-	f.Uint64(
-		prefix+".bloom-bits-blocks", DefaultConfig.BloomBitsBlocks,
-		"number of blocks a single bloom bit section vector holds",
-	)
-	f.Uint64(
-		prefix+".feehistory-max-block-count", DefaultConfig.FeeHistoryMaxBlockCount,
-		"max number of blocks a fee history request may cover",
-	)
-	f.String(
-		prefix+".classic-redirect", DefaultConfig.ClassicRedirect,
-		"url to redirect classic requests, use \"error:[CODE:]MESSAGE\" to return specified error instead of redirecting",
-	)
+	f.Uint64(prefix+".gas-cap", DefaultConfig.RPCGasCap, "cap on computation gas that can be used in eth_call/estimateGas (0=infinite)")
+	f.Float64(prefix+".tx-fee-cap", DefaultConfig.RPCTxFeeCap, "cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)")
+	f.Duration(prefix+".evm-timeout", DefaultConfig.RPCEVMTimeout, "timeout used for eth_call (0=infinite)")
+	f.Uint64(prefix+".bloom-bits-blocks", DefaultConfig.BloomBitsBlocks, "number of blocks a single bloom bit section vector holds")
+	f.Uint64(prefix+".feehistory-max-block-count", DefaultConfig.FeeHistoryMaxBlockCount, "max number of blocks a fee history request may cover")
+	f.String(prefix+".classic-redirect", DefaultConfig.ClassicRedirect, "url to redirect classic requests, use \"error:[CODE:]MESSAGE\" to return specified error instead of redirecting")
 
 	arbDebug := DefaultConfig.ArbDebug
-	f.Uint64(
-		prefix+".arbdebug.block-range-bound", arbDebug.BlockRangeBound,
-		"bounds the number of blocks arbdebug calls may return",
-	)
-	f.Uint64(
-		prefix+".arbdebug.timeout-queue-bound", arbDebug.TimeoutQueueBound,
-		"bounds the length of timeout queues arbdebug calls may return",
-	)
+	f.Uint64(prefix+".arbdebug.block-range-bound", arbDebug.BlockRangeBound, "bounds the number of blocks arbdebug calls may return")
+	f.Uint64(prefix+".arbdebug.timeout-queue-bound", arbDebug.TimeoutQueueBound, "bounds the length of timeout queues arbdebug calls may return")
 }
 
 var DefaultConfig = Config{


### PR DESCRIPTION
Adds a new `ArbDebugConfig` under `RPC` to limit `arbdebug` outputs