### PR TITLE
set ErrUseFallback code and message directly

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -37,22 +37,6 @@ type APIBackend struct {
 	fallbackClient types.FallbackClient
 }
 
-type ErrorFallbackClient struct {
-	err error
-}
-
-type FallBackError struct {
-	msg  string
-	code int
-}
-
-func (e *FallBackError) ErrorCode() int { return e.code }
-func (e *FallBackError) Error() string  { return e.msg }
-
-func (f *ErrorFallbackClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	return f.err
-}
-
 func createFallbackClient(fallbackClientUrl string) (types.FallbackClient, error) {
 	if fallbackClientUrl == "" {
 		return nil, nil
@@ -65,12 +49,8 @@ func createFallbackClient(fallbackClientUrl string) (types.FallbackClient, error
 		} else {
 			errNumber = -32000
 		}
-		return &ErrorFallbackClient{
-			err: &FallBackError{
-				msg:  strings.Join(fields, ":"),
-				code: int(errNumber),
-			},
-		}, nil
+		types.SetFallbackError(strings.Join(fields, ":"), int(errNumber))
+		return nil, nil
 	}
 	fallbackClient, err := rpc.Dial(fallbackClientUrl)
 	if fallbackClient == nil || err != nil {

--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -22,7 +22,7 @@ var fallbackErrorCode = -32001
 func SetFallbackError(msg string, code int) {
 	fallbackErrorMsg = msg
 	fallbackErrorCode = code
-	log.Info("setting fallback", "msg", msg, "code", code)
+	log.Debug("setting fallback error", "msg", msg, "code", code)
 }
 
 func (f fallbackError) ErrorCode() int { return fallbackErrorCode }

--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -16,7 +16,7 @@ import (
 type fallbackError struct {
 }
 
-var fallbackErrorMsg = "I seem to be missing trie node 0000000000000000000000000000000000000000000000000000000000000000 (path )"
+var fallbackErrorMsg = "missing trie node 0000000000000000000000000000000000000000000000000000000000000000 (path ) <nil>"
 var fallbackErrorCode = -32001
 
 func SetFallbackError(msg string, code int) {

--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -17,7 +17,7 @@ type fallbackError struct {
 }
 
 var fallbackErrorMsg = "missing trie node 0000000000000000000000000000000000000000000000000000000000000000 (path ) <nil>"
-var fallbackErrorCode = -32001
+var fallbackErrorCode = -32000
 
 func SetFallbackError(msg string, code int) {
 	fallbackErrorMsg = msg

--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -3,17 +3,32 @@ package types
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var ErrUseFallback = errors.New("missing trie node 0000000000000000000000000000000000000000000000000000000000000000 (path )")
+type fallbackError struct {
+}
+
+var fallbackErrorMsg = "I seem to be missing trie node 0000000000000000000000000000000000000000000000000000000000000000 (path )"
+var fallbackErrorCode = -32001
+
+func SetFallbackError(msg string, code int) {
+	fallbackErrorMsg = msg
+	fallbackErrorCode = code
+	log.Info("setting fallback", "msg", msg, "code", code)
+}
+
+func (f fallbackError) ErrorCode() int { return fallbackErrorCode }
+func (f fallbackError) Error() string  { return fallbackErrorMsg }
+
+var ErrUseFallback = fallbackError{}
 
 type FallbackClient interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error


### PR DESCRIPTION
this uses the same error message even if not wrapped by a fallback client call (e.g. debug namespace)