### PR TITLE
add l1blockNumber for classic blocks

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1333,15 +1333,57 @@ func (s *PublicBlockChainAPI) rpcMarshalHeader(ctx context.Context, header *type
 	return fields
 }
 
+func (s *PublicBlockChainAPI) arbClassicL1BlockNumber(ctx context.Context, block *types.Block) (hexutil.Uint64, error) {
+	chainConfig := s.b.ChainConfig()
+	blockNum := block.Number().Int64()
+	i := 0
+	for {
+		transactions := block.Transactions()
+		if len(transactions) > 0 {
+			legacyTx, ok := transactions[0].GetInner().(*types.ArbitrumLegacyTxData)
+			if !ok {
+				return 0, fmt.Errorf("couldn't read legacy transaction from block %d", blockNum)
+			}
+			return hexutil.Uint64(legacyTx.L1BlockNumber), nil
+		}
+		blockNum++
+		var err error
+		block, err = s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
+		if err != nil {
+			return 0, err
+		}
+		if blockNum >= int64(chainConfig.ArbitrumChainParams.GenesisBlockNum) {
+			info, err := types.DeserializeHeaderExtraInformation(block.Header())
+			if err != nil {
+				return 0, err
+			}
+			return hexutil.Uint64(info.L1BlockNumber), nil
+		}
+		i++
+		if i > 5 {
+			return 0, fmt.Errorf("couldn't find block with transactions. Reached %d", blockNum)
+		}
+	}
+}
+
 // rpcMarshalBlock uses the generalized output filler, then adds the total difficulty field, which requires
 // a `PublicBlockchainAPI`.
 func (s *PublicBlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlock(b, inclTx, fullTx, s.b.ChainConfig())
+	chainConfig := s.b.ChainConfig()
+	fields, err := RPCMarshalBlock(b, inclTx, fullTx, chainConfig)
 	if err != nil {
 		return nil, err
 	}
 	if inclTx {
 		fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, b.Hash()))
+	}
+	if chainConfig.IsArbitrum() && !chainConfig.IsArbitrumNitro(b.Number()) {
+		l1BlockNumber, err := s.arbClassicL1BlockNumber(ctx, b)
+		if err != nil {
+			log.Error("error trying to fill legacy l1BlockNumber", "err", err)
+		} else {
+			fields["l1BlockNumber"] = hexutil.Uint64(l1BlockNumber)
+		}
 	}
 	return fields, err
 }

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -105,7 +105,7 @@ func ArbitrumDevTestParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       3,
+		InitialArbOSVersion:       5,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -115,7 +115,7 @@ func ArbitrumDevTestDASParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       3,
+		InitialArbOSVersion:       5,
 		InitialChainOwner:         common.Address{},
 	}
 }


### PR DESCRIPTION
This adds l1BlockNumber to classic blocks.
BlockNumber is taken from first transaction. If that doesn't exist - first transaction of next block with one. Up to 5 blocks are scanned (in rinkeby there is at most a 2-block empty streak)