### PR TITLE
commit triedb on cap

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -491,6 +491,7 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 				return nil
 			}
 		}
+		t.triedb.Commit(parent.root, true, nil)
 	default:
 		panic(fmt.Sprintf("unknown data layer: %T", parent))
 	}


### PR DESCRIPTION
cap seems to assume that the bottom layeys triedb is already committed.
Make sure this is true.