### PR TITLE
Make newRevertError have consistent prefix

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1034,10 +1034,9 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 	err := errors.New("execution reverted")
 	if errUnpack == nil {
 		err = fmt.Errorf("execution reverted: %v", reason)
-	}
-	if core.RenderRPCError != nil {
+	} else if core.RenderRPCError != nil {
 		if arbErr := core.RenderRPCError(result.Revert()); arbErr != nil {
-			err = arbErr
+			err = fmt.Errorf("execution reverted: %w", arbErr)
 		}
 	}
 	return &revertError{


### PR DESCRIPTION
This makes it so the `newRevertError` function always returns an error message starting with "execution reverted"