### PR TITLE
Add CLI opt to disable RPC metric histogram reset

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -79,6 +79,7 @@ The dumpgenesis command dumps the genesis block configuration in JSON format to 
 			utils.CacheGCFlag,
 			utils.MetricsEnabledFlag,
 			utils.MetricsEnabledExpensiveFlag,
+			utils.MetricsDisableRPCHistogramResetFlag,
 			utils.MetricsHTTPFlag,
 			utils.MetricsPortFlag,
 			utils.MetricsEnableInfluxDBFlag,

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -229,6 +229,9 @@ func applyMetricConfig(ctx *cli.Context, cfg *gethConfig) {
 	if ctx.IsSet(utils.MetricsEnabledExpensiveFlag.Name) {
 		cfg.Metrics.EnabledExpensive = ctx.Bool(utils.MetricsEnabledExpensiveFlag.Name)
 	}
+	if ctx.IsSet(utils.MetricsDisableRPCHistogramResetFlag.Name) {
+		cfg.Metrics.DisabledRPCHistogramReset = ctx.Bool(utils.MetricsDisableRPCHistogramResetFlag.Name)
+	}
 	if ctx.IsSet(utils.MetricsHTTPFlag.Name) {
 		cfg.Metrics.HTTP = ctx.String(utils.MetricsHTTPFlag.Name)
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -189,6 +189,7 @@ var (
 	metricsFlags = []cli.Flag{
 		utils.MetricsEnabledFlag,
 		utils.MetricsEnabledExpensiveFlag,
+		utils.MetricsDisableRPCHistogramResetFlag,
 		utils.MetricsHTTPFlag,
 		utils.MetricsPortFlag,
 		utils.MetricsEnableInfluxDBFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -887,6 +887,11 @@ var (
 		Usage:    "Enable expensive metrics collection and reporting",
 		Category: flags.MetricsCategory,
 	}
+	MetricsDisableRPCHistogramResetFlag = &cli.BoolFlag{
+		Name:     "metrics.disable-rpc-histogram-reset",
+		Usage:    "Disable resetting the per-RPC duration histogram when the metrics endpoint is scraped",
+		Category: flags.MetricsCategory,
+	}
 
 	// MetricsHTTPFlag defines the endpoint for a stand-alone metrics HTTP endpoint.
 	// Since the pprof service enables sensitive/vulnerable behavior, this allows a user

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -18,16 +18,17 @@ package metrics
 
 // Config contains the configuration for the metric collection.
 type Config struct {
-	Enabled          bool   `toml:",omitempty"`
-	EnabledExpensive bool   `toml:",omitempty"`
-	HTTP             string `toml:",omitempty"`
-	Port             int    `toml:",omitempty"`
-	EnableInfluxDB   bool   `toml:",omitempty"`
-	InfluxDBEndpoint string `toml:",omitempty"`
-	InfluxDBDatabase string `toml:",omitempty"`
-	InfluxDBUsername string `toml:",omitempty"`
-	InfluxDBPassword string `toml:",omitempty"`
-	InfluxDBTags     string `toml:",omitempty"`
+	Enabled                   bool   `toml:",omitempty"`
+	EnabledExpensive          bool   `toml:",omitempty"`
+	DisabledRPCHistogramReset bool   `toml:",omitempty"`
+	HTTP                      string `toml:",omitempty"`
+	Port                      int    `toml:",omitempty"`
+	EnableInfluxDB            bool   `toml:",omitempty"`
+	InfluxDBEndpoint          string `toml:",omitempty"`
+	InfluxDBDatabase          string `toml:",omitempty"`
+	InfluxDBUsername          string `toml:",omitempty"`
+	InfluxDBPassword          string `toml:",omitempty"`
+	InfluxDBTags              string `toml:",omitempty"`
 
 	EnableInfluxDBV2     bool   `toml:",omitempty"`
 	InfluxDBToken        string `toml:",omitempty"`

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -26,11 +26,21 @@ var Enabled = false
 // for health monitoring and debug metrics that might impact runtime performance.
 var EnabledExpensive = false
 
+// DisableRPCHistogramReset controls whether the per-RPC duration histogram is
+// reset each time the metrics endpoint is scraped, or not.
+// The legacy behavior is to reset the histogram and it is likely that some
+// installations depend on this, so the histogram resets by default.
+var DisabledRPCHistogramReset = false
+
 // enablerFlags is the CLI flag names to use to enable metrics collections.
 var enablerFlags = []string{"metrics"}
 
 // expensiveEnablerFlags is the CLI flag names to use to enable metrics collections.
 var expensiveEnablerFlags = []string{"metrics.expensive"}
+
+// disableRPCHistogramResetFlags is the CLI flag names to use to disable resetting
+// the per-RPC duration histogram when the metrics endpoint is scraped.
+var disableRPCHistogramResetFlags = []string{"metrics.disable-rpc-histogram-reset"}
 
 // Init enables or disables the metrics system. Since we need this to run before
 // any other code gets to create meters and timers, we'll actually do an ugly hack
@@ -49,6 +59,12 @@ func init() {
 			if !EnabledExpensive && flag == enabler {
 				log.Info("Enabling expensive metrics collection")
 				EnabledExpensive = true
+			}
+		}
+		for _, enabler := range disableRPCHistogramResetFlags {
+			if !DisabledRPCHistogramReset && flag == enabler {
+				log.Info("Disabling per-RPC duration histogram reset on scrape")
+				DisabledRPCHistogramReset = true
 			}
 		}
 	}

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -42,9 +42,12 @@ func updateServeTimeHistogram(method string, success bool, elapsed time.Duration
 	}
 	h := fmt.Sprintf("%s/%s/%s", serveTimeHistName, method, note)
 	sampler := func() metrics.Sample {
-		return metrics.ResettingSample(
-			metrics.NewExpDecaySample(1028, 0.015),
-		)
+		var sample metrics.Sample
+		sample = metrics.NewExpDecaySample(1028, 0.015)
+		if !metrics.DisabledRPCHistogramReset {
+			sample = metrics.ResettingSample(sample)
+		}
+		return sample
 	}
 	metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(elapsed.Microseconds())
 }


### PR DESCRIPTION
All RPC methods produce a metric called rpc/duration/methodname/success and /failure. This metric is implemented as an exponential forward decaying sampler, and prior to this change the sampler was always cleared when the metrics endpoint was scraped, using metrics.ResettingSampler. There is a note in resetting_sample.go that this is done to avoid having metrics for low frequence events be skewed by old samples, and that this may "break for multi-monitor systems".

This change adds a command line option to turn off resetting the sampler for these metrics. For installations with a high scrape rate of the metrics endpoint, if the sampler is reset every scrape then this skews results by finding the quantiles over too small a set of samples, so a simple way of turning off the reset would be an improvement. The old behavior is preserved by default so as not to break any installations that have come to depend on this behavior.

Ultimately to get good running approximations of the quantiles the reservoir size of the sampler would be tunable for each event, based on the expected frequency of that event, and the time period the quantile was desired to be calculated over (some RPC methods get more traffic than others). This is, however, too much confiuration to expose at the command line, so this change just exposes on/off for resetting the samplers.

# Testing done
Ran without new flag
```
$ ./build/bin/geth --metrics --metrics.port 6080 --metrics.addr 127.0.0.1 --networkid 12345 --http 
```

Ran with new flag
```
$ ./build/bin/geth --metrics --metrics.port 6080 --metrics.addr 127.0.0.1 --networkid 12345 --http --metrics.disable-rpc-histogram-reset
```

Observed using watch and curl to see if the metric gets reset or not depending on whether the flag is set.
```
$ watch 'curl localhost:6080/debug/metrics/prometheus | grep -i getbalance'

# TYPE rpc_duration_eth_getBalance_failure_count counter
rpc_duration_eth_getBalance_failure_count 6
# TYPE rpc_duration_eth_getBalance_failure summary
rpc_duration_eth_getBalance_failure {quantile="0.5"} 76.5
rpc_duration_eth_getBalance_failure {quantile="0.75"} 96
rpc_duration_eth_getBalance_failure {quantile="0.95"} 99
rpc_duration_eth_getBalance_failure {quantile="0.99"} 99
rpc_duration_eth_getBalance_failure {quantile="0.999"} 99
rpc_duration_eth_getBalance_failure {quantile="0.9999"} 99
```

```
curl -v http://localhost:8545 -X POST -H "Content-Type: application/json" -d '{"method":"eth_getBalance","params":["0xdF8107D1758D1D7dCfB29511557bC92DAa119174", "0x1"],"id":117,"jsonrpc":"2.0"}'
```