### PR TITLE
unpack args in timeoutFallbackClient.CallContext

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -46,7 +46,7 @@ type timeoutFallbackClient struct {
 func (c *timeoutFallbackClient) CallContext(ctxIn context.Context, result interface{}, method string, args ...interface{}) error {
 	ctx, cancel := context.WithTimeout(ctxIn, c.timeout)
 	defer cancel()
-	return c.impl.CallContext(ctx, result, method, args)
+	return c.impl.CallContext(ctx, result, method, args...)
 }
 
 func createFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.Duration) (types.FallbackClient, error) {

--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -49,7 +49,7 @@ func (c *timeoutFallbackClient) CallContext(ctxIn context.Context, result interf
 	return c.impl.CallContext(ctx, result, method, args...)
 }
 
-func createFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.Duration) (types.FallbackClient, error) {
+func CreateFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.Duration) (types.FallbackClient, error) {
 	if fallbackClientUrl == "" {
 		return nil, nil
 	}
@@ -84,7 +84,7 @@ type SyncProgressBackend interface {
 }
 
 func createRegisterAPIBackend(backend *Backend, sync SyncProgressBackend, fallbackClientUrl string, fallbackClientTimeout time.Duration) error {
-	fallbackClient, err := createFallbackClient(fallbackClientUrl, fallbackClientTimeout)
+	fallbackClient, err := CreateFallbackClient(fallbackClientUrl, fallbackClientTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Arguments passed to CallContext were not unpacked, as a result they were wrapped into a slice and marshaled as an array