### PR TITLE
Retryable RetryTo field should not be required in JSON unmarshalling

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -591,9 +591,6 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.Gas == nil {
 			return errors.New("missing required field 'gas' in txdata")
 		}
-		if dec.RetryTo == nil {
-			return errors.New("missing required field 'retryTo' in txdata")
-		}
 		if dec.Beneficiary == nil {
 			return errors.New("missing required field 'beneficiary' in transaction")
 		}


### PR DESCRIPTION
This field is nil in the case of a retryable that functions as a contract creation