### PR TITLE
Mark startup later for the unclean shutdown tracker

### DIFF
--- a/arbitrum/backend.go
+++ b/arbitrum/backend.go
@@ -55,7 +55,6 @@ func NewBackend(stack *node.Node, config *Config, chainDb ethdb.Database, publis
 	if err != nil {
 		return nil, nil, err
 	}
-	backend.shutdownTracker.MarkStartup()
 	return backend, filterSystem, nil
 }
 
@@ -86,6 +85,7 @@ func (b *Backend) ArbInterface() ArbInterface {
 // TODO: this is used when registering backend as lifecycle in stack
 func (b *Backend) Start() error {
 	b.startBloomHandlers(b.config.BloomBitsBlocks)
+	b.shutdownTracker.MarkStartup()
 	b.shutdownTracker.Start()
 
 	return nil


### PR DESCRIPTION
If the backend is created but not started, that shouldn't count as an unclean shutdown.