### PR TITLE
Add ContractAddress to stored receipt fields for arb txs

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -131,8 +130,8 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, author *com
 	receipt.GasUsed = result.UsedGas
 
 	// If the transaction created a contract, store the creation address in the receipt.
-	if msg.To() == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+	if result.TopLevelDeployed != nil {
+		receipt.ContractAddress = *result.TopLevelDeployed
 	}
 
 	// Set the receipt logs and create the bloom filter.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -91,7 +91,8 @@ type ExecutionResult struct {
 	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
 
 	// Arbitrum: a tx may yield others that need to run afterward (see retryables)
-	ScheduledTxes    types.Transactions
+	ScheduledTxes types.Transactions
+	// Arbitrum: the contract deployed from the top-level transaction, or nil if not a contract creation tx
 	TopLevelDeployed *common.Address
 }
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -102,6 +102,7 @@ type storedReceiptRLP struct {
 	CumulativeGasUsed uint64
 	L1GasUsed         uint64
 	Logs              []*LogForStorage
+	ContractAddress   *common.Address `rlp:"optional"` // set on new versions if an Arbitrum tx type
 }
 
 type arbLegacyStoredReceiptRLP struct {
@@ -313,6 +314,9 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 		}
 	}
 	w.ListEnd(logList)
+	if r.Type >= ArbitrumDepositTxType && r.Type != ArbitrumLegacyTxType && r.ContractAddress != (common.Address{}) {
+		w.WriteBytes(r.ContractAddress[:])
+	}
 	w.ListEnd(outerList)
 	return w.Flush()
 }
@@ -379,6 +383,9 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 		r.Logs[i] = (*Log)(log)
 	}
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+	if stored.ContractAddress != nil {
+		r.ContractAddress = *stored.ContractAddress
+	}
 
 	return nil
 }
@@ -464,7 +471,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 
 		if rs[i].Type != ArbitrumLegacyTxType {
 			// The contract address can be derived from the transaction itself
-			if txs[i].To() == nil {
+			if txs[i].To() == nil && rs[i].ContractAddress == (common.Address{}) {
 				// Deriving the signer is expensive, only do if it's actually needed
 				from, _ := Sender(signer, txs[i])
 				rs[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())


### PR DESCRIPTION
This fixes the contractAddress field of receipts for arbitrum tx types that have a "fake" nonce which doesn't match the state nonce, such as ArbitrumContractTx and ArbitrumRetryableTx.

Note that the ContractAddress field is non-consensus so this isn't a breaking change.