### PR TITLE
Supply a RunMode everywhere we make a message

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -928,7 +928,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		config.BlockOverrides.Apply(&vmctx)
 	}
 	// Execute the trace
-	msg, err := args.ToMessage(api.backend.RPCGasCap(), block.Header(), statedb)
+	msg, err := args.ToMessage(api.backend.RPCGasCap(), block.Header(), statedb, types.MessageEthcallMode)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1072,7 +1072,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, err := ethapi.DoCall(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, b.r.backend.RPCEVMTimeout(), b.r.backend.RPCGasCap(), false)
+	result, err := ethapi.DoCall(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, b.r.backend.RPCEVMTimeout(), b.r.backend.RPCGasCap(), types.MessageEthcallMode)
 	if err != nil {
 		return nil, err
 	}
@@ -1142,7 +1142,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, err := ethapi.DoCall(ctx, p.r.backend, args.Data, pendingBlockNr, nil, p.r.backend.RPCEVMTimeout(), p.r.backend.RPCGasCap(), false)
+	result, err := ethapi.DoCall(ctx, p.r.backend, args.Data, pendingBlockNr, nil, p.r.backend.RPCEVMTimeout(), p.r.backend.RPCGasCap(), types.MessageEthcallMode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is helpful now that `InterceptRPCGasCap` cares about the run mode.