### PR TITLE
Re-added the TypeString Parameter to: gen_callframe_json.go

### DIFF
--- a/eth/tracers/native/gen_callframe_json.go
+++ b/eth/tracers/native/gen_callframe_json.go
@@ -27,6 +27,7 @@ func (c callFrame) MarshalJSON() ([]byte, error) {
 		Calls              []callFrame         `json:"calls,omitempty" rlp:"optional"`
 		Logs               []callLog           `json:"logs,omitempty" rlp:"optional"`
 		Value              *big.Int            `json:"value,omitempty" rlp:"optional"`
+		TypeString	   string              `json:"type"
 	}
 	var enc callFrame0
 	enc.BeforeEVMTransfers = c.BeforeEVMTransfers
@@ -43,6 +44,7 @@ func (c callFrame) MarshalJSON() ([]byte, error) {
 	enc.Calls = c.Calls
 	enc.Logs = c.Logs
 	enc.Value = c.Value
+	enc.TypeString = c.TypeString()
 	return json.Marshal(&enc)
 }
 

--- a/eth/tracers/native/gen_callframe_json.go
+++ b/eth/tracers/native/gen_callframe_json.go
@@ -27,7 +27,7 @@ func (c callFrame) MarshalJSON() ([]byte, error) {
 		Calls              []callFrame         `json:"calls,omitempty" rlp:"optional"`
 		Logs               []callLog           `json:"logs,omitempty" rlp:"optional"`
 		Value              *big.Int            `json:"value,omitempty" rlp:"optional"`
-		TypeString	   string              `json:"type"
+		TypeString	   string              `json:"type"`
 	}
 	var enc callFrame0
 	enc.BeforeEVMTransfers = c.BeforeEVMTransfers


### PR DESCRIPTION
Re-added the `TypeString` parameter, shown as `type` when placing `debug_traceTransaction` calls. This was missing on Arbitrum Nitro v2.1.0, yet available on prior versions.

Example JSONRPC response with the type parameter:

`{"afterEVMTransfers":[],"beforeEVMTransfers":[],"from":"0x00000000000000000000000000000000000a4b05","gas":"0x0","gasUsed":"0xe420","input":"0x6bf6a42d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000106e62200000000000000000000000000000000000000000000000000000000055176760000000000000000000000000000000000000000000000000000000000000000","output":"0x","to":"0x00000000000000000000000000000000000a4b05","type":"CALL","value":"0x0"}`