### PR TITLE
lint fixes from @CaraWang

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -218,7 +218,7 @@ func (a *APIBackend) FeeHistory(
 
 	// use the most recent average compute rate for all blocks
 	// note: while we could query this value for each block, it'd be prohibitively expensive
-	state, _, err := a.StateAndHeaderByNumber(ctx, rpc.BlockNumber(newestBlock))
+	state, _, err := a.StateAndHeaderByNumber(ctx, newestBlock)
 	if err != nil {
 		return common.Big0, nil, nil, nil, err
 	}

--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -179,7 +179,6 @@ func (a *APIBackend) FeeHistory(
 	newestBlock rpc.BlockNumber,
 	rewardPercentiles []float64,
 ) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
-
 	if core.GetArbOSSpeedLimitPerSecond == nil {
 		return nil, nil, nil, nil, errors.New("ArbOS not installed")
 	}
@@ -284,7 +283,6 @@ func (a *APIBackend) FeeHistory(
 			fullnessAnalogue = 1.0
 		}
 		gasUsed[block-oldestBlock] = fullnessAnalogue
-
 	}
 	if newestBlock == latestBlock {
 		basefees[blocks] = basefees[blocks-1] // guess the basefee won't change

--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -68,7 +68,7 @@ func CreateFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.D
 	var fallbackClient types.FallbackClient
 	var err error
 	fallbackClient, err = rpc.Dial(fallbackClientUrl)
-	if fallbackClient == nil || err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("failed creating fallback connection: %w", err)
 	}
 	if fallbackClientTimeout != 0 {
@@ -160,7 +160,7 @@ func (a *APIBackend) SyncProgressMap() map[string]interface{} {
 func (a *APIBackend) SyncProgress() ethereum.SyncProgress {
 	progress := a.sync.SyncProgressMap()
 
-	if progress == nil || len(progress) == 0 {
+	if len(progress) == 0 {
 		return ethereum.SyncProgress{}
 	}
 	return ethereum.SyncProgress{

--- a/arbitrum/recordingdb.go
+++ b/arbitrum/recordingdb.go
@@ -320,7 +320,7 @@ func (r *RecordingDatabase) GetOrRecreateState(ctx context.Context, header *type
 		}
 		err = r.addStateVerify(stateDb, block.Root())
 		if err != nil {
-			return nil, fmt.Errorf("failed commiting state for block %d : %w", blockToRecreate, err)
+			return nil, fmt.Errorf("failed committing state for block %d : %w", blockToRecreate, err)
 		}
 		r.dereferenceRoot(lastRoot)
 		lastRoot = block.Root()

--- a/arbitrum/recordingdb.go
+++ b/arbitrum/recordingdb.go
@@ -113,9 +113,7 @@ func (db *RecordingKV) Close() error {
 	return nil
 }
 
-func (db *RecordingKV) Release() {
-	return
-}
+func (db *RecordingKV) Release() {}
 
 func (db *RecordingKV) GetRecordedEntries() map[common.Hash][]byte {
 	return db.readDbEntries

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -430,12 +430,12 @@ func (s *StateDB) SubBalance(addr common.Address, amount *big.Int) {
 func (s *StateDB) SetBalance(addr common.Address, amount *big.Int) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		if amount != nil {
-			prevBalance := stateObject.Balance()
-			s.unexpectedBalanceDelta.Add(s.unexpectedBalanceDelta, amount)
-			s.unexpectedBalanceDelta.Sub(s.unexpectedBalanceDelta, prevBalance)
+		if amount == nil {
+			amount = big.NewInt(0)
 		}
-
+		prevBalance := stateObject.Balance()
+		s.unexpectedBalanceDelta.Add(s.unexpectedBalanceDelta, amount)
+		s.unexpectedBalanceDelta.Sub(s.unexpectedBalanceDelta, prevBalance)
 		stateObject.SetBalance(amount)
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -430,9 +430,11 @@ func (s *StateDB) SubBalance(addr common.Address, amount *big.Int) {
 func (s *StateDB) SetBalance(addr common.Address, amount *big.Int) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		prevBalance := stateObject.Balance()
-		s.unexpectedBalanceDelta.Add(s.unexpectedBalanceDelta, amount)
-		s.unexpectedBalanceDelta.Sub(s.unexpectedBalanceDelta, prevBalance)
+		if amount != nil {
+			prevBalance := stateObject.Balance()
+			s.unexpectedBalanceDelta.Add(s.unexpectedBalanceDelta, amount)
+			s.unexpectedBalanceDelta.Sub(s.unexpectedBalanceDelta, prevBalance)
+		}
 
 		stateObject.SetBalance(amount)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -461,9 +461,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// Arbitrum: record self destructs
 	if st.evm.Config.Debug {
-		for _, address := range st.evm.StateDB.GetSuicides() {
+		suicides := st.evm.StateDB.GetSuicides()
+		for i, address := range suicides {
 			balance := st.evm.StateDB.GetBalance(address)
-			st.evm.Config.Tracer.CaptureArbitrumTransfer(st.evm, &address, nil, balance, false, "selfDestruct")
+			st.evm.Config.Tracer.CaptureArbitrumTransfer(st.evm, &suicides[i], nil, balance, false, "selfDestruct")
 		}
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -478,7 +478,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 }
 
 func (st *StateTransition) refundGas(refundQuotient uint64) {
-
 	st.gasRemaining += st.evm.ProcessingHook.ForceRefundGas()
 
 	nonrefundable := st.evm.ProcessingHook.NonrefundableGas()

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -145,7 +145,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.Value = (*hexutil.Big)(itx.Value)
 		enc.To = tx.To()
 	case *ArbitrumUnsignedTx:
-		enc.From = (*common.Address)(&itx.From)
+		enc.From = &itx.From
 		enc.ChainID = (*hexutil.Big)(itx.ChainId)
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
 		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
@@ -163,7 +163,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.Data = (*hexutil.Bytes)(&itx.Data)
 		enc.To = tx.To()
 	case *ArbitrumRetryTx:
-		enc.From = (*common.Address)(&itx.From)
+		enc.From = &itx.From
 		enc.TicketId = &itx.TicketId
 		enc.RefundTo = &itx.RefundTo
 		enc.ChainID = (*hexutil.Big)(itx.ChainId)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -428,7 +428,6 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 }
 
 func opGasprice(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-
 	// Arbitrum: provide an opportunity to remove the tip from the gas price
 	gasPrice := interpreter.evm.ProcessingHook.GasPriceOp(interpreter.evm)
 

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -28,7 +28,7 @@ import (
 // Note that reference types are actual VM data structures; make copies
 // if you need to retain them beyond the current call.
 type EVMLogger interface {
-	// Arbitrum: capture a transfer, mint, or burn that happens outside of EVM exectuion
+	// Arbitrum: capture a transfer, mint, or burn that happens outside of EVM execution
 	CaptureArbitrumTransfer(env *EVM, from, to *common.Address, value *big.Int, before bool, purpose string)
 	CaptureArbitrumStorageGet(key common.Hash, depth int, before bool)
 	CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool)

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -133,6 +133,7 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, e
 	// and is populated on start and end.
 	return &callTracer{
 		callstack:          make([]callFrame, 1),
+		config:             config,
 		beforeEVMTransfers: []arbitrumTransfer{},
 		afterEVMTransfers:  []arbitrumTransfer{},
 	}, nil

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -103,7 +103,7 @@ type callFrameMarshaling struct {
 }
 
 type callTracer struct {
-	// Arbitrum: capture transfers occuring outside of evm execution
+	// Arbitrum: capture transfers occurring outside of evm execution
 	beforeEVMTransfers []arbitrumTransfer
 	afterEVMTransfers  []arbitrumTransfer
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1409,7 +1409,7 @@ func (s *BlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, inc
 		if err != nil {
 			log.Error("error trying to fill legacy l1BlockNumber", "err", err)
 		} else {
-			fields["l1BlockNumber"] = hexutil.Uint64(l1BlockNumber)
+			fields["l1BlockNumber"] = l1BlockNumber
 		}
 	}
 	return fields, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -132,7 +132,7 @@ func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecim
 func (s *EthereumAPI) Syncing() (interface{}, error) {
 	progress := s.b.SyncProgressMap()
 
-	if progress == nil || len(progress) == 0 {
+	if len(progress) == 0 {
 		return false, nil
 	}
 	return progress, nil

--- a/metrics/chunked_associative_array.go
+++ b/metrics/chunked_associative_array.go
@@ -4,10 +4,11 @@ package metrics
 // https://github.com/dropwizard/metrics/blob/release/4.2.x/metrics-core/src/main/java/com/codahale/metrics/ChunkedAssociativeLongArray.java
 
 import (
-	"github.com/gammazero/deque"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/gammazero/deque"
 )
 
 const (


### PR DESCRIPTION
This PR cherry picks most of the lint fixes from https://github.com/OffchainLabs/go-ethereum/pull/208 from @CaraWang, with some manual conflict resolution done.

The following table shows the commits from the original PR, and whether they were included or not. 

```
| Title                                                                 | Commit  | Status                                           |
|-----------------------------------------------------------------------+---------+--------------------------------------------------|
| core/state: check amount object existence                             | 3017631 | cherry-picked                                    |
| eth/tracers: pass config to callTracer                                | e6e6f4d | cherry-picked                                    |
| cmd/evm: add L1 gas used                                              | 22f9f5a | already fixed on master                          |
| rpc: fix SA1019: jwt.StandardClaims is deprecated                     | 7298902 | jwt code changed on master, no longer applicable |
| metrics, core: fix G601 and goimports issues                          | ae568b6 | cherry-picked                                    |
| *: fix S1009, S1023, and SA4023 lint issues                           | 1eee4fe | cherry-picked                                    |
| internal/ethapi: implement SyncProgressMap and FallbackClient for bac | 6ea71f0 | already fixed on master                          |
| *: fix misspelling and unnecessary conversion                         | e994cec | cherry-picked, resolved conflicts                |
| *: fix unnecessary leading newline                                    | a75a204 | cherry-picked, resolved conflicts                |
| core: use DefaultTriesInMemory in test                                | c9da1e6 | already fixed on master                          |
```


