### PR TITLE
Fix nonce checks being enabled for Arbitrum "fake" txs

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -173,7 +173,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 		Value:             tx.Value(),
 		Data:              tx.Data(),
 		AccessList:        tx.AccessList(),
-		SkipAccountChecks: false,
+		SkipAccountChecks: tx.SkipAccountChecks(),
 	}
 	// If baseFee provided, set gasPrice to effectiveGasPrice.
 	if baseFee != nil {

--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -12,6 +12,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// Returns true if nonce checks should be skipped based on inner's isFake()
+// This also disables requiring that sender is an EOA and not a contract
+func (tx *Transaction) SkipAccountChecks() bool {
+	return tx.inner.isFake()
+}
+
 type fallbackError struct {
 }
 


### PR DESCRIPTION
Transactions such as L1->L2 contract transactions should bypass nonce checks, as they previously did via IsFake, which has been renamed to SkipAccountChecks in recent geth versions.