### PR TITLE
Resurrect freezer migrate

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
 	"github.com/ethereum/go-ethereum/accounts/usbwallet"
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/internal/ethapi"

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
 	"github.com/ethereum/go-ethereum/accounts/usbwallet"
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/internal/ethapi"

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/console/prompt"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/flags"
@@ -68,6 +69,7 @@ Remove blockchain and state databases`,
 			dbImportCmd,
 			dbExportCmd,
 			dbMetadataCmd,
+			dbMigrateFreezerCmd,
 			dbCheckStateContentCmd,
 		},
 	}
@@ -192,6 +194,17 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 			utils.SyncModeFlag,
 		}, utils.NetworkFlags, utils.DatabasePathFlags),
 		Description: "Shows metadata about the chain status.",
+	}
+	dbMigrateFreezerCmd = &cli.Command{
+		Action:    freezerMigrate,
+		Name:      "freezer-migrate",
+		Usage:     "Migrate legacy parts of the freezer. (WARNING: may take a long time)",
+		ArgsUsage: "",
+		Flags: flags.Merge([]cli.Flag{
+			utils.SyncModeFlag,
+		}, utils.NetworkFlags, utils.DatabasePathFlags),
+		Description: `The freezer-migrate command checks your database for receipts in a legacy format and updates those.
+WARNING: please back-up the receipt files in your ancients before running this command.`,
 	}
 )
 
@@ -712,4 +725,93 @@ func showMetaData(ctx *cli.Context) error {
 	table.AppendBulk(data)
 	table.Render()
 	return nil
+}
+
+func freezerMigrate(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, false)
+	defer db.Close()
+
+	// Check first block for legacy receipt format
+	numAncients, err := db.Ancients()
+	if err != nil {
+		return err
+	}
+	if numAncients < 1 {
+		log.Info("No receipts in freezer to migrate")
+		return nil
+	}
+
+	isFirstLegacy, firstIdx, err := dbHasLegacyReceipts(db, 0)
+	if err != nil {
+		return err
+	}
+	if !isFirstLegacy {
+		log.Info("No legacy receipts to migrate")
+		return nil
+	}
+
+	log.Info("Starting migration", "ancients", numAncients, "firstLegacy", firstIdx)
+	start := time.Now()
+	if err := db.MigrateTable("receipts", types.ConvertLegacyStoredReceipts); err != nil {
+		return err
+	}
+	if err := db.Close(); err != nil {
+		return err
+	}
+	log.Info("Migration finished", "duration", time.Since(start))
+
+	return nil
+}
+
+// dbHasLegacyReceipts checks freezer entries for legacy receipts. It stops at the first
+// non-empty receipt and checks its format. The index of this first non-empty element is
+// the second return parameter.
+func dbHasLegacyReceipts(db ethdb.Database, firstIdx uint64) (bool, uint64, error) {
+	// Check first block for legacy receipt format
+	numAncients, err := db.Ancients()
+	if err != nil {
+		return false, 0, err
+	}
+	if numAncients < 1 {
+		return false, 0, nil
+	}
+	if firstIdx >= numAncients {
+		return false, firstIdx, nil
+	}
+	var (
+		legacy       bool
+		blob         []byte
+		emptyRLPList = []byte{192}
+	)
+	// Find first block with non-empty receipt, only if
+	// the index is not already provided.
+	if firstIdx == 0 {
+		for i := uint64(0); i < numAncients; i++ {
+			blob, err = db.Ancient("receipts", i)
+			if err != nil {
+				return false, 0, err
+			}
+			if len(blob) == 0 {
+				continue
+			}
+			if !bytes.Equal(blob, emptyRLPList) {
+				firstIdx = i
+				break
+			}
+		}
+	}
+	first, err := db.Ancient("receipts", firstIdx)
+	if err != nil {
+		return false, 0, err
+	}
+	// We looped over all receipts and they were all empty
+	if bytes.Equal(first, emptyRLPList) {
+		return false, 0, nil
+	}
+	// Is first non-empty receipt legacy?
+	legacy, err = types.IsLegacyStoredReceipts(first)
+	return legacy, firstIdx, err
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -149,6 +149,7 @@ var (
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
 		utils.MinerNotifyFullFlag,
+		utils.IgnoreLegacyReceiptsFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -112,8 +112,9 @@ var (
 	}
 	ChaindataFlag = &flags.DirectoryFlag{
 		Name:     "datadir.chaindata",
-		Usage:    "Root directory for chaindata dir (default = inside chaindata)",
+		Usage:    "Root directory for chaindata dir (default = 'chaindata')",
 		Category: flags.EthCategory,
+		Value:    "chaindata",
 	}
 	MinFreeDiskSpaceFlag = &flags.DirectoryFlag{
 		Name:     "datadir.minfreedisk",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -110,6 +110,11 @@ var (
 		Usage:    "Root directory for ancient data (default = inside chaindata)",
 		Category: flags.EthCategory,
 	}
+	ChaindataFlag = &flags.DirectoryFlag{
+		Name:     "datadir.chaindata",
+		Usage:    "Root directory for chaindata dir (default = inside chaindata)",
+		Category: flags.EthCategory,
+	}
 	MinFreeDiskSpaceFlag = &flags.DirectoryFlag{
 		Name:     "datadir.minfreedisk",
 		Usage:    "Minimum free disk space in MB, once reached triggers auto shut down (default = --cache.gc converted to MB, 0 = disabled)",
@@ -1015,6 +1020,7 @@ var (
 	DatabasePathFlags = []cli.Flag{
 		DataDirFlag,
 		AncientFlag,
+		ChaindataFlag,
 		RemoteDBFlag,
 		HttpHeaderFlag,
 	}
@@ -1784,6 +1790,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(AncientFlag.Name) {
 		cfg.DatabaseFreezer = ctx.String(AncientFlag.Name)
 	}
+	if ctx.IsSet(ChaindataFlag.Name) {
+		cfg.DatabaseChaindata = ctx.String(ChaindataFlag.Name)
+	}
 
 	if gcmode := ctx.String(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
@@ -2166,7 +2175,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	case ctx.String(SyncModeFlag.Name) == "light":
 		chainDb, err = stack.OpenDatabase("lightchaindata", cache, handles, "", readonly)
 	default:
-		chainDb, err = stack.OpenDatabaseWithFreezer("chaindata", cache, handles, ctx.String(AncientFlag.Name), "", readonly)
+		chainDb, err = stack.OpenDatabaseWithFreezer(ctx.String(ChaindataFlag.Name), cache, handles, ctx.String(AncientFlag.Name), "", readonly)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -660,6 +660,11 @@ var (
 	}
 
 	// MISC settings
+	IgnoreLegacyReceiptsFlag = &cli.BoolFlag{
+		Name:     "ignore-legacy-receipts",
+		Usage:    "Geth will start up even if there are legacy receipts in freezer",
+		Category: flags.MiscCategory,
+	}
 	SyncTargetFlag = &cli.PathFlag{
 		Name:      "synctarget",
 		Usage:     `File for containing the hex-encoded block-rlp as sync target(dev feature)`,

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -676,7 +676,6 @@ func DeleteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 
 // storedReceiptRLP is the storage encoding of a receipt.
 // Re-definition in core/types/receipt.go.
-// TODO: Re-use the existing definition.
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
@@ -698,7 +697,10 @@ func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&stored); err != nil {
 		return err
 	}
-	r.Logs = stored.Logs
+	r.Logs = make([]*types.Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*types.Log)(log)
+	}
 	return nil
 }
 
@@ -734,10 +736,30 @@ func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.C
 	}
 	receipts := []*receiptLogs{}
 	if err := rlp.DecodeBytes(data, &receipts); err != nil {
+		// Receipts might be in the legacy format, try decoding that.
+		// TODO: to be removed after users migrated
+		if logs := readLegacyLogs(db, hash, number, config); logs != nil {
+			return logs
+		}
 		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
 		return nil
 	}
 
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
+	}
+	return logs
+}
+
+// readLegacyLogs is a temporary workaround for when trying to read logs
+// from a block which has its receipt stored in the legacy format. It'll
+// be removed after users have migrated their freezer databases.
+func readLegacyLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) [][]*types.Log {
+	receipts := ReadReceipts(db, hash, number, config)
+	if receipts == nil {
+		return nil
+	}
 	logs := make([][]*types.Log, len(receipts))
 	for i, receipt := range receipts {
 		logs[i] = receipt.Logs

--- a/core/types/legacy.go
+++ b/core/types/legacy.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// IsLegacyStoredReceipts tries to parse the RLP-encoded blob
+// first as an array of v3 stored receipt, then v4 stored receipt and
+// returns true if successful.
+func IsLegacyStoredReceipts(raw []byte) (bool, error) {
+	var v3 []v3StoredReceiptRLP
+	if err := rlp.DecodeBytes(raw, &v3); err == nil {
+		return true, nil
+	}
+	var v4 []v4StoredReceiptRLP
+	if err := rlp.DecodeBytes(raw, &v4); err == nil {
+		return true, nil
+	}
+	var v5 []storedReceiptRLP
+	// Check to see valid fresh stored receipt
+	if err := rlp.DecodeBytes(raw, &v5); err == nil {
+		return false, nil
+	}
+	return false, errors.New("value is not a valid receipt encoding")
+}
+
+// ConvertLegacyStoredReceipts takes the RLP encoding of an array of legacy
+// stored receipts and returns a fresh RLP-encoded stored receipt.
+func ConvertLegacyStoredReceipts(raw []byte) ([]byte, error) {
+	var receipts []ReceiptForStorage
+	if err := rlp.DecodeBytes(raw, &receipts); err != nil {
+		return nil, err
+	}
+	return rlp.EncodeToBytes(&receipts)
+}

--- a/core/types/legacy.go
+++ b/core/types/legacy.go
@@ -39,6 +39,10 @@ func IsLegacyStoredReceipts(raw []byte) (bool, error) {
 	if err := rlp.DecodeBytes(raw, &v5); err == nil {
 		return false, nil
 	}
+	var arbReceipt []arbLegacyStoredReceiptRLP
+	if err := rlp.DecodeBytes(raw, &arbReceipt); err == nil {
+		return true, nil
+	}
 	return false, errors.New("value is not a valid receipt encoding")
 }
 

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -64,11 +64,22 @@ type logMarshaling struct {
 
 //go:generate go run ../../rlp/rlpgen -type rlpLog -out gen_log_rlp.go
 
-// rlpLog is used to RLP-encode both the consensus and storage formats.
 type rlpLog struct {
 	Address common.Address
 	Topics  []common.Hash
 	Data    []byte
+}
+
+// legacyRlpStorageLog is the previous storage encoding of a log including some redundant fields.
+type legacyRlpStorageLog struct {
+	Address     common.Address
+	Topics      []common.Hash
+	Data        []byte
+	BlockNumber uint64
+	TxHash      common.Hash
+	TxIndex     uint
+	BlockHash   common.Hash
+	Index       uint
 }
 
 // EncodeRLP implements rlp.Encoder.
@@ -83,6 +94,47 @@ func (l *Log) DecodeRLP(s *rlp.Stream) error {
 	err := s.Decode(&dec)
 	if err == nil {
 		l.Address, l.Topics, l.Data = dec.Address, dec.Topics, dec.Data
+	}
+	return err
+}
+
+// LogForStorage is a wrapper around a Log that handles
+// backward compatibility with prior storage formats.
+type LogForStorage Log
+
+// EncodeRLP implements rlp.Encoder.
+func (l *LogForStorage) EncodeRLP(w io.Writer) error {
+	rl := rlpLog{Address: l.Address, Topics: l.Topics, Data: l.Data}
+	return rlp.Encode(w, &rl)
+}
+
+// DecodeRLP implements rlp.Decoder.
+//
+// Note some redundant fields(e.g. block number, tx hash etc) will be assembled later.
+func (l *LogForStorage) DecodeRLP(s *rlp.Stream) error {
+	blob, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	var dec rlpLog
+	err = rlp.DecodeBytes(blob, &dec)
+	if err == nil {
+		*l = LogForStorage{
+			Address: dec.Address,
+			Topics:  dec.Topics,
+			Data:    dec.Data,
+		}
+	} else {
+		// Try to decode log with previous definition.
+		var dec legacyRlpStorageLog
+		err = rlp.DecodeBytes(blob, &dec)
+		if err == nil {
+			*l = LogForStorage{
+				Address: dec.Address,
+				Topics:  dec.Topics,
+				Data:    dec.Data,
+			}
+		}
 	}
 	return err
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -101,7 +101,7 @@ type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	L1GasUsed         uint64
-	Logs              []*Log
+	Logs              []*LogForStorage
 	ContractAddress   *common.Address `rlp:"optional"` // set on new versions if an Arbitrum tx type
 }
 
@@ -112,7 +112,7 @@ type arbLegacyStoredReceiptRLP struct {
 	L1GasUsed         uint64
 	Status            uint64
 	ContractAddress   common.Address
-	Logs              []*Log
+	Logs              []*LogForStorage
 }
 
 // v4StoredReceiptRLP is the storage encoding of a receipt used in database version 4.
@@ -121,7 +121,7 @@ type v4StoredReceiptRLP struct {
 	CumulativeGasUsed uint64
 	TxHash            common.Hash
 	ContractAddress   common.Address
-	Logs              []*Log
+	Logs              []*LogForStorage
 	GasUsed           uint64
 }
 
@@ -132,7 +132,7 @@ type v3StoredReceiptRLP struct {
 	Bloom             Bloom
 	TxHash            common.Hash
 	ContractAddress   common.Address
-	Logs              []*Log
+	Logs              []*LogForStorage
 	GasUsed           uint64
 }
 
@@ -335,7 +335,15 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 	if err := decodeStoredReceiptRLP(r, blob); err == nil {
 		return nil
 	}
-	return decodeArbitrumLegacyStoredReceiptRLP(r, blob)
+
+	if err := decodeArbitrumLegacyStoredReceiptRLP(r, blob); err == nil {
+		return nil
+	}
+
+	if err := decodeV3StoredReceiptRLP(r, blob); err == nil {
+		return nil
+	}
+	return decodeV4StoredReceiptRLP(r, blob)
 }
 
 func decodeArbitrumLegacyStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
@@ -369,12 +377,56 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	}
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
 	r.GasUsedForL1 = stored.L1GasUsed
-	r.Logs = stored.Logs
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
 	if stored.ContractAddress != nil {
 		r.ContractAddress = *stored.ContractAddress
 	}
 
+	return nil
+}
+
+func decodeV4StoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
+	var stored v4StoredReceiptRLP
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.TxHash = stored.TxHash
+	r.ContractAddress = stored.ContractAddress
+	r.GasUsed = stored.GasUsed
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
+	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+
+	return nil
+}
+
+func decodeV3StoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
+	var stored v3StoredReceiptRLP
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.Bloom = stored.Bloom
+	r.TxHash = stored.TxHash
+	r.ContractAddress = stored.ContractAddress
+	r.GasUsed = stored.GasUsed
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
 	return nil
 }
 

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -92,6 +92,136 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 	}
 }
 
+func TestLegacyReceiptDecoding(t *testing.T) {
+	tests := []struct {
+		name   string
+		encode func(*Receipt) ([]byte, error)
+	}{
+		{
+			"ReceiptForStorage",
+			encodeAsReceiptForStorage,
+		},
+		{
+			"StoredReceiptRLP",
+			encodeAsStoredReceiptRLP,
+		},
+		{
+			"V4StoredReceiptRLP",
+			encodeAsV4StoredReceiptRLP,
+		},
+		{
+			"V3StoredReceiptRLP",
+			encodeAsV3StoredReceiptRLP,
+		},
+	}
+
+	tx := NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), nil)
+	receipt := &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		TxHash:          tx.Hash(),
+		ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+		GasUsed:         111111,
+	}
+	receipt.Bloom = CreateBloom(Receipts{receipt})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.encode(receipt)
+			if err != nil {
+				t.Fatalf("Error encoding receipt: %v", err)
+			}
+			var dec ReceiptForStorage
+			if err := rlp.DecodeBytes(enc, &dec); err != nil {
+				t.Fatalf("Error decoding RLP receipt: %v", err)
+			}
+			// Check whether all consensus fields are correct.
+			if dec.Status != receipt.Status {
+				t.Fatalf("Receipt status mismatch, want %v, have %v", receipt.Status, dec.Status)
+			}
+			if dec.CumulativeGasUsed != receipt.CumulativeGasUsed {
+				t.Fatalf("Receipt CumulativeGasUsed mismatch, want %v, have %v", receipt.CumulativeGasUsed, dec.CumulativeGasUsed)
+			}
+			if dec.Bloom != receipt.Bloom {
+				t.Fatalf("Bloom data mismatch, want %v, have %v", receipt.Bloom, dec.Bloom)
+			}
+			if len(dec.Logs) != len(receipt.Logs) {
+				t.Fatalf("Receipt log number mismatch, want %v, have %v", len(receipt.Logs), len(dec.Logs))
+			}
+			for i := 0; i < len(dec.Logs); i++ {
+				if dec.Logs[i].Address != receipt.Logs[i].Address {
+					t.Fatalf("Receipt log %d address mismatch, want %v, have %v", i, receipt.Logs[i].Address, dec.Logs[i].Address)
+				}
+				if !reflect.DeepEqual(dec.Logs[i].Topics, receipt.Logs[i].Topics) {
+					t.Fatalf("Receipt log %d topics mismatch, want %v, have %v", i, receipt.Logs[i].Topics, dec.Logs[i].Topics)
+				}
+				if !bytes.Equal(dec.Logs[i].Data, receipt.Logs[i].Data) {
+					t.Fatalf("Receipt log %d data mismatch, want %v, have %v", i, receipt.Logs[i].Data, dec.Logs[i].Data)
+				}
+			}
+		})
+	}
+}
+
+func encodeAsReceiptForStorage(want *Receipt) ([]byte, error) {
+	return rlp.EncodeToBytes((*ReceiptForStorage)(want))
+}
+
+func encodeAsStoredReceiptRLP(want *Receipt) ([]byte, error) {
+	stored := &storedReceiptRLP{
+		PostStateOrStatus: want.statusEncoding(),
+		CumulativeGasUsed: want.CumulativeGasUsed,
+		Logs:              make([]*LogForStorage, len(want.Logs)),
+	}
+	for i, log := range want.Logs {
+		stored.Logs[i] = (*LogForStorage)(log)
+	}
+	return rlp.EncodeToBytes(stored)
+}
+
+func encodeAsV4StoredReceiptRLP(want *Receipt) ([]byte, error) {
+	stored := &v4StoredReceiptRLP{
+		PostStateOrStatus: want.statusEncoding(),
+		CumulativeGasUsed: want.CumulativeGasUsed,
+		TxHash:            want.TxHash,
+		ContractAddress:   want.ContractAddress,
+		Logs:              make([]*LogForStorage, len(want.Logs)),
+		GasUsed:           want.GasUsed,
+	}
+	for i, log := range want.Logs {
+		stored.Logs[i] = (*LogForStorage)(log)
+	}
+	return rlp.EncodeToBytes(stored)
+}
+
+func encodeAsV3StoredReceiptRLP(want *Receipt) ([]byte, error) {
+	stored := &v3StoredReceiptRLP{
+		PostStateOrStatus: want.statusEncoding(),
+		CumulativeGasUsed: want.CumulativeGasUsed,
+		Bloom:             want.Bloom,
+		TxHash:            want.TxHash,
+		ContractAddress:   want.ContractAddress,
+		Logs:              make([]*LogForStorage, len(want.Logs)),
+		GasUsed:           want.GasUsed,
+	}
+	for i, log := range want.Logs {
+		stored.Logs[i] = (*LogForStorage)(log)
+	}
+	return rlp.EncodeToBytes(stored)
+}
+
 // Tests that receipt data can be correctly derived from the contextual infos
 func TestDeriveFields(t *testing.T) {
 	// Create a few transactions to have receipts for

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -159,6 +159,7 @@ type Config struct {
 	DatabaseHandles    int  `toml:"-"`
 	DatabaseCache      int
 	DatabaseFreezer    string
+	DatabaseChaindata  string
 
 	TrieCleanCache          int
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts


### PR DESCRIPTION
This PR brings back the "geth db freezer-migrate" tool in order for Nitro users to migrate legacy RLP receipts. Legacy receipt support, including support for migration, was dropped in v1.11.0 of geth and its users were supposed to have migrated before upgrading. 

For Arbitrum One, classic (pre-nitro) receipts were encoded in the legacy format, so eth_getLogs requests were failing for classic blocks: https://github.com/OffchainLabs/nitro/issues/1745

# Testing done
## Migrate the snapshot 
```
$ mkdir -p /home/tristan/offchain/geth-upgrade/freezer-repair-7/arb1
$ tar xf ~/Downloads/nitro-genesis.tar -C /home/tristan/offchain/geth-upgrade/freezer-repair-7/arb1
$ ./build/bin/geth db freezer-migrate --datadir "/home/tristan/offchain/geth-upgrade/freezer-repair-7/arb1" --datadir.chaindata "../nitro/l2chaindata"
...
INFO [07-26|16:18:18.670] Replacing old table files with migrated ones elapsed=8m10.089s
[[[sync /home/tristan/offchain/geth-upgrade/freezer-repair-7/arb1/nitro/l2chaindata/ancient/receipts.0004.cdat: file already closed]]]
```
The final error message about trying to sync a closed file can be ignored, the migration is complete.

## Start older Nitro version
Start a version of Nitro where the support for legacy receipts has been removed.
```
$ ./target/bin/nitro --parent-chain.connection.url {L1 ID} --chain.id=42161 --node.rpc.classic-redirect=https://arb1.arbitrum.io/rpc   --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*  --persistent.global-config /home/tristan/offchain/geth-upgrade/freezer-repair-7
```

## test eth_getLogs
Check the block reported by @kaber2 (165)
```
$ curl 'http://localhost:8547' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0xA5", "toBlock":"0xA5"}]}' > a5_local
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2269    0  2172  100    97  1831k  83765 --:--:-- --:--:-- --:--:-- 2215k
$ curl 'https://arb1.arbitrum.io/rpc' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0xA5", "toBlock":"0xA5"}]}' > a5_remote
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2269    0  2172  100    97  24358   1087 --:--:-- --:--:-- --:--:-- 25211
$ diff a5_local a5_remote 
```

Check around the classic/nitro boundary (first nitro block is = 22207817)
```
$ curl 'https://arb1.arbitrum.io/rpc' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0x152DD40", "toBlock":"0x152DD50"}]}' > classic_nitro_remote
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12542    0 12435  100   107   172k   1518 --:--:-- --:--:-- --:--:--  174k
$ curl 'http://localhost:8547' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0x152DD40", "toBlock":"0x152DD50"}]}' > classic_nitro_local
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12542    0 12435  100   107  4129k  36382 --:--:-- --:--:-- --:--:-- 6124k
$ diff classic_nitro_local classic_nitro_remote
```
