### PR TITLE
Bring back ArbitrumLegacy receipt reading for logs

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -734,10 +734,30 @@ func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.C
 	}
 	receipts := []*receiptLogs{}
 	if err := rlp.DecodeBytes(data, &receipts); err != nil {
+		if logs := readLegacyLogs(db, hash, number, config); logs != nil {
+			return logs
+		}
+
 		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
 		return nil
 	}
 
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
+	}
+	return logs
+}
+
+// readLegacyLogs is a temporary workaround for when trying to read logs
+// from a block which has its receipt stored in the legacy format. It'll
+// be removed after users have migrated their freezer databases.
+// Arbitrum: we are keeping this to handle classic (legacy) receipts
+func readLegacyLogs(db ethdb.Reader, hash common.Hash, number uint64, config *params.ChainConfig) [][]*types.Log {
+	receipts := ReadReceipts(db, hash, number, config)
+	if receipts == nil {
+		return nil
+	}
 	logs := make([][]*types.Log, len(receipts))
 	for i, receipt := range receipts {
 		logs[i] = receipt.Logs


### PR DESCRIPTION
Classic (pre-Nitro) receipts are stored as arbLegacyStoredReceiptRLPs. We had removed reading of them for serving ReadLogs by mistake when merging in upstream geth changes to remove their legacy receipt format. This change adds the code path back in that will trigger ReceiptForStorage.DecodeRLP, which first tries the new stored receipt format and then uses the Arbitrum legacy format, when reading logs.

This fixes https://github.com/OffchainLabs/nitro/issues/1745

# Testing done
## Extract the snapshot
```
$ mkdir -p /home/tristan/offchain/geth-upgrade/nitro-genesis-2/arb1
$ tar xf ~/Downloads/nitro-genesis.tar -C /home/tristan/offchain/geth-upgrade/nitro-genesis-2/arb1
```

## Start Nitro version
```
$ ./target/bin/nitro --parent-chain.connection.url {L1 ID} --chain.id=42161 --node.rpc.classic-redirect=https://arb1.arbitrum.io/rpc   --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*  --persistent.global-config /home/tristan/offchain/geth-upgrade/nitro-genesis-2
```

## test eth_getLogs
Check the block reported by @kaber2 (165)
```
$ curl 'http://localhost:8547' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0xA5", "toBlock":"0xA5"}]}' > a5_local
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2269    0  2172  100    97  1831k  83765 --:--:-- --:--:-- --:--:-- 2215k
$ curl 'https://arb1.arbitrum.io/rpc' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0xA5", "toBlock":"0xA5"}]}' > a5_remote
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2269    0  2172  100    97  24358   1087 --:--:-- --:--:-- --:--:-- 25211
$ diff a5_local a5_remote 
```

Check around the classic/nitro boundary (first nitro block is = 22207817)
```
$ curl 'https://arb1.arbitrum.io/rpc' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0x152DD40", "toBlock":"0x152DD50"}]}' > classic_nitro_remote
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12542    0 12435  100   107   172k   1518 --:--:-- --:--:-- --:--:--  174k
$ curl 'http://localhost:8547' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_getLogs","params":[{"fromBlock":"0x152DD40", "toBlock":"0x152DD50"}]}' > classic_nitro_local
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12542    0 12435  100   107  4129k  36382 --:--:-- --:--:-- --:--:-- 6124k
$ diff classic_nitro_local classic_nitro_remote
```
