### PR TITLE
Immediately return an error from updateTrie if DeleteStorage fails

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -330,7 +330,10 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 	if len(keysToDelete) > 0 {
 		sort.Slice(keysToDelete, func(i, j int) bool { return bytes.Compare(keysToDelete[i][:], keysToDelete[j][:]) < 0 })
 		for _, key := range keysToDelete {
-			s.db.setError(tr.DeleteStorage(s.address, key[:]))
+			if err := tr.DeleteStorage(s.address, key[:]); err != nil {
+				s.db.setError(err)
+				return nil, err
+			}
 			s.db.StorageDeleted += 1
 		}
 	}


### PR DESCRIPTION
The code modified in this PR is the deterministic trie deletion code which we added. Upstream go-ethereum modified the non-deterministic case to immediately return an error if DeleteStorage fails, so we should do the same in the deterministic case.