### PR TITLE
fix memory leak in StateAtBlock

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -85,6 +85,7 @@ func (eth *Ethereum) StateAtBlock(ctx context.Context, block *types.Block, reexe
 			// Create an ephemeral trie.Database for isolating the live one. Otherwise
 			// the internal junks created by tracing will be persisted into the disk.
 			database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16})
+			defer database.TrieDB().ResetCleans()
 			if statedb, err = state.New(block.Root(), database, nil); err == nil {
 				log.Info("Found disk backend for state trie", "root", block.Root(), "number", block.Number())
 				return statedb, noopReleaser, nil
@@ -100,6 +101,7 @@ func (eth *Ethereum) StateAtBlock(ctx context.Context, block *types.Block, reexe
 		// Create an ephemeral trie.Database for isolating the live one. Otherwise
 		// the internal junks created by tracing will be persisted into the disk.
 		database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16})
+		defer database.TrieDB().ResetCleans()
 
 		// If we didn't check the live database, do check state over ephemeral database,
 		// otherwise we would rewind past a persisted block (specific corner case is

--- a/trie/database_wrap.go
+++ b/trie/database_wrap.go
@@ -84,6 +84,7 @@ func prepare(diskdb ethdb.Database, config *Config) *Database {
 		} else {
 			cleans = fastcache.LoadFromFileOrNew(config.Journal, config.Cache*1024*1024)
 		}
+		runtime.SetFinalizer(cleans, func(c *fastcache.Cache) { c.Reset() })
 	}
 	var preimages *preimageStore
 	if config != nil && config.Preimages {
@@ -94,6 +95,13 @@ func prepare(diskdb ethdb.Database, config *Config) *Database {
 		diskdb:    diskdb,
 		cleans:    cleans,
 		preimages: preimages,
+	}
+}
+
+// resets fastcache to return memory chunks to pool of free chunks
+func (db *Database) ResetCleans() {
+	if db.cleans != nil {
+		db.cleans.Reset()
 	}
 }
 


### PR DESCRIPTION
* adds cleans cache finalizer to return used mmaped memory chunks to the global pool (fastcache)
* trigger cleans cache reset early when recreating state