### PR TITLE
Backport "Make contract size limit configurable" to v2.1.2

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -172,7 +172,7 @@ func Transaction(ctx *cli.Context) error {
 			r.Error = errors.New("gas * maxFeePerGas exceeds 256 bits")
 		}
 		// Check whether the init code size has been exceeded.
-		if chainConfig.IsShanghai(new(big.Int), 0, 0) && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
+		if chainConfig.IsShanghai(new(big.Int), 0, 0) && tx.To() == nil && len(tx.Data()) > int(chainConfig.MaxInitCodeSize()) {
 			r.Error = errors.New("max initcode size exceeded")
 		}
 		results = append(results, r)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -408,8 +408,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	// Check whether the init code size has been exceeded.
-	if rules.IsShanghai && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
-		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
+	if rules.IsShanghai && contractCreation && len(msg.Data) > int(st.evm.ChainConfig().MaxInitCodeSize()) {
+		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), int(st.evm.ChainConfig().MaxInitCodeSize()))
 	}
 
 	// Execute the preparatory steps for state transition which includes:

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -615,8 +615,8 @@ func (pool *TxPool) validateTxBasics(tx *types.Transaction, local bool) error {
 		return ErrOversizedData
 	}
 	// Check whether the init code size has been exceeded.
-	if pool.shanghai.Load() && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
-		return fmt.Errorf("%w: code size %v limit %v", core.ErrMaxInitCodeSizeExceeded, len(tx.Data()), params.MaxInitCodeSize)
+	if pool.shanghai.Load() && tx.To() == nil && len(tx.Data()) > int(pool.chainconfig.MaxInitCodeSize()) {
+		return fmt.Errorf("%w: code size %v limit %v", core.ErrMaxInitCodeSizeExceeded, len(tx.Data()), int(pool.chainconfig.MaxInitCodeSize()))
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur if you create a transaction using the RPC.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -504,7 +504,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	ret, err := evm.interpreter.Run(contract, nil, false)
 
 	// Check whether the max code size has been exceeded, assign err if the case.
-	if err == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
+	if err == nil && evm.chainRules.IsEIP158 && len(ret) > int(evm.chainConfig.MaxCodeSize()) {
 		err = ErrMaxCodeSizeExceeded
 	}
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -308,10 +308,10 @@ func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 		return 0, err
 	}
 	size, overflow := stack.Back(2).Uint64WithOverflow()
-	if overflow || size > params.MaxInitCodeSize {
+	if overflow || size > evm.chainConfig.MaxInitCodeSize() {
 		return 0, ErrGasUintOverflow
 	}
-	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
+	// Since size <= evm.chainConfig.MaxInitCodeSize(), these multiplication cannot overflow
 	moreGas := params.InitCodeWordGas * ((size + 31) / 32)
 	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {
 		return 0, ErrGasUintOverflow
@@ -324,10 +324,10 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 		return 0, err
 	}
 	size, overflow := stack.Back(2).Uint64WithOverflow()
-	if overflow || size > params.MaxInitCodeSize {
+	if overflow || size > evm.chainConfig.MaxInitCodeSize() {
 		return 0, ErrGasUintOverflow
 	}
-	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
+	// Since size <= evm.chainConfig.MaxInitCodeSize(), these multiplication cannot overflow
 	moreGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ((size + 31) / 32)
 	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {
 		return 0, ErrGasUintOverflow

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -29,6 +29,8 @@ type ArbitrumChainParams struct {
 	InitialArbOSVersion       uint64
 	InitialChainOwner         common.Address
 	GenesisBlockNum           uint64
+	MaxCodeSize               uint64 `json:"MaxCodeSize,omitempty"`     // Maximum bytecode to permit for a contract. 0 value implies params.MaxCodeSize
+	MaxInitCodeSize           uint64 `json:"MaxInitCodeSize,omitempty"` // Maximum initcode to permit in a creation transaction and create instructions. 0 value implies params.MaxInitCodeSize
 }
 
 func (c *ChainConfig) IsArbitrum() bool {
@@ -37,6 +39,20 @@ func (c *ChainConfig) IsArbitrum() bool {
 
 func (c *ChainConfig) IsArbitrumNitro(num *big.Int) bool {
 	return c.IsArbitrum() && isBlockForked(new(big.Int).SetUint64(c.ArbitrumChainParams.GenesisBlockNum), num)
+}
+
+func (c *ChainConfig) MaxCodeSize() uint64 {
+	if c.ArbitrumChainParams.MaxCodeSize == 0 {
+		return MaxCodeSize
+	}
+	return c.ArbitrumChainParams.MaxCodeSize
+}
+
+func (c *ChainConfig) MaxInitCodeSize() uint64 {
+	if c.ArbitrumChainParams.MaxInitCodeSize == 0 {
+		return c.MaxCodeSize() * 2
+	}
+	return c.ArbitrumChainParams.MaxInitCodeSize
 }
 
 func (c *ChainConfig) DebugMode() bool {


### PR DESCRIPTION
Backports https://github.com/OffchainLabs/go-ethereum/pull/255 to the go-ethereum pin corresponding to nitro v2.1.2