### PR TITLE
fastcache fix update for v.1.12.1

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -85,6 +85,7 @@ func (eth *Ethereum) StateAtBlock(ctx context.Context, block *types.Block, reexe
 			// Create an ephemeral trie.Database for isolating the live one. Otherwise
 			// the internal junks created by tracing will be persisted into the disk.
 			database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16})
+			defer database.TrieDB().Close()
 			if statedb, err = state.New(block.Root(), database, nil); err == nil {
 				log.Info("Found disk backend for state trie", "root", block.Root(), "number", block.Number())
 				return statedb, noopReleaser, nil
@@ -100,6 +101,7 @@ func (eth *Ethereum) StateAtBlock(ctx context.Context, block *types.Block, reexe
 		// Create an ephemeral trie.Database for isolating the live one. Otherwise
 		// the internal junks created by tracing will be persisted into the disk.
 		database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16})
+		defer database.TrieDB().Close()
 
 		// If we didn't check the live database, do check state over ephemeral database,
 		// otherwise we would rewind past a persisted block (specific corner case is

--- a/trie/triedb/hashdb/database.go
+++ b/trie/triedb/hashdb/database.go
@@ -635,7 +635,13 @@ func (db *Database) Size() common.StorageSize {
 }
 
 // Close closes the trie database and releases all held resources.
-func (db *Database) Close() error { return nil }
+func (db *Database) Close() error {
+	if db.cleans != nil {
+		// Reset cleans cache to return mmaped memory chunks to fastcache pool
+		db.cleans.Reset()
+	}
+	return nil
+}
 
 // Scheme returns the node scheme used in the database.
 func (db *Database) Scheme() string {

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -344,6 +344,13 @@ func (db *Database) Close() error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
+	dl := db.tree.bottom()
+	if dl.cleans != nil {
+		// Reset cleans cache to return mmaped memory chunks to fastcache pool
+		// We need to do that only for one diskLayer as all diskLayers share the same cleans cache
+		dl.cleans.Reset()
+	}
+
 	db.readOnly = true
 	if db.freezer == nil {
 		return nil

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -347,7 +347,7 @@ func (db *Database) Close() error {
 	dl := db.tree.bottom()
 	if dl.cleans != nil {
 		// Reset cleans cache to return mmaped memory chunks to fastcache pool
-		// We need to do that only for one diskLayer as all diskLayers share the same cleans cache
+		// All diskLayers share the same cleans cache
 		dl.cleans.Reset()
 	}
 


### PR DESCRIPTION
This PR resolves conflict caused by https://github.com/OffchainLabs/go-ethereum/pull/264

* setting fastcache finalizer is moved to fastcache fork: https://github.com/OffchainLabs/fastcache/pull/1
* instead of exposing `fastcache.Cache.Reset()` via new `ResetCleans` method, `trie.backend.Close()` implementations are updated in `hashdb.Database.Close` and `pathdb.Database.Close` to reset corresponding caches