### PR TITLE
Revert "core/state: mark account as dirty when resetObject occurs"

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -180,6 +180,12 @@ func (ch resetObjectChange) revert(s *StateDB) {
 }
 
 func (ch resetObjectChange) dirtied() *common.Address {
+	// Arbitrum: We keep the behavior that existed before go-ethereum v1.12.1 and return nil,
+	// instead of returning the reset address as upstream go-ethereum v1.12.1 does.
+	// That's because, unlike for go-ethereum, whether this account is dirty or not is relevant for Arbitrum.
+	// Arbitrum hooks manipulate the state in some ways that go-ethereum doesn't which cause that relevance,
+	// e.g. subtracting balance from an account that hasn't been otherwise touched.
+	// See https://github.com/OffchainLabs/nitro/pull/1976 for details
 	return nil
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -90,7 +90,6 @@ type (
 		account *common.Address
 	}
 	resetObjectChange struct {
-		account      *common.Address
 		prev         *stateObject
 		prevdestruct bool
 		prevAccount  []byte
@@ -181,7 +180,7 @@ func (ch resetObjectChange) revert(s *StateDB) {
 }
 
 func (ch resetObjectChange) dirtied() *common.Address {
-	return ch.account
+	return nil
 }
 
 func (ch selfDestructChange) revert(s *StateDB) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -718,7 +718,6 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 		// cache the latest account/storage data.
 		prevAccount, ok := s.accountsOrigin[prev.address]
 		s.journal.append(resetObjectChange{
-			account:                &addr,
 			prev:                   prev,
 			prevdestruct:           prevdestruct,
 			prevAccount:            s.accounts[prev.addrHash],

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -365,6 +365,8 @@ func (test *stateTest) verify(root common.Hash, next common.Hash, db *trie.Datab
 }
 
 func TestStateChanges(t *testing.T) {
+	t.Skip("Arbitrum doesn't support some of these operations due to https://github.com/OffchainLabs/go-ethereum/pull/271")
+
 	config := &quick.Config{MaxCount: 1000}
 	err := quick.Check((*stateTest).run, config)
 	if cerr, ok := err.(*quick.CheckError); ok {


### PR DESCRIPTION
This reverts commit 15bd21f3c878155bc2254bb43460763298f58ad1.

This worked for upstream go-ethereum, but some ways we manipulate the state means this changes behavior for us