### PR TITLE
ethdb/pebble: don't double-close iterator inside pebbleIterator

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -567,9 +567,12 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 
 // pebbleIterator is a wrapper of underlying iterator in storage engine.
 // The purpose of this structure is to implement the missing APIs.
+//
+// The pebble iterator is not thread-safe.
 type pebbleIterator struct {
-	iter  *pebble.Iterator
-	moved bool
+	iter     *pebble.Iterator
+	moved    bool
+	released bool
 }
 
 // NewIterator creates a binary-alphabetical iterator over a subset
@@ -581,7 +584,7 @@ func (d *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 		UpperBound: upperBound(prefix),
 	})
 	iter.First()
-	return &pebbleIterator{iter: iter, moved: true}
+	return &pebbleIterator{iter: iter, moved: true, released: false}
 }
 
 // Next moves the iterator to the next key/value pair. It returns whether the
@@ -616,4 +619,9 @@ func (iter *pebbleIterator) Value() []byte {
 
 // Release releases associated resources. Release should always succeed and can
 // be called multiple times without causing error.
-func (iter *pebbleIterator) Release() { iter.iter.Close() }
+func (iter *pebbleIterator) Release() {
+	if !iter.released {
+		iter.iter.Close()
+		iter.released = true
+	}
+}


### PR DESCRIPTION
Adds released flag to pebbleIterator to avoid double closing cockroachdb/pebble.Iterator as it is an invalid operation.

This PR backports: https://github.com/ethereum/go-ethereum/pull/28566
Fixes: https://github.com/ethereum/go-ethereum/issues/28565