### PR TITLE
Increase classic L1 block search limit

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1466,7 +1466,7 @@ func (s *BlockChainAPI) arbClassicL1BlockNumber(ctx context.Context, block *type
 		}
 		i++
 		blockNum = startBlockNum - i
-		if i > 5 {
+		if i > 50 {
 			return 0, fmt.Errorf("couldn't find block with transactions. Reached %d", blockNum)
 		}
 		var err error


### PR DESCRIPTION
There only seems to be a maximum gap of 8 classic blocks without transactions, but this PR increases the limit to 50 to be safe.