### PR TITLE
Enable Cancun fork in ArbOS 20

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -284,6 +285,9 @@ func opBlobHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 // opBlobBaseFee implements BLOBBASEFEE opcode
 func opBlobBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	if interpreter.evm.chainConfig.IsArbitrum() {
+		return nil, errors.New("BLOBBASEFEE is not supported on Arbitrum")
+	}
 	blobBaseFee, _ := uint256.FromBig(interpreter.evm.Context.BlobBaseFee)
 	scope.Stack.push(blobBaseFee)
 	return nil, nil

--- a/params/config.go
+++ b/params/config.go
@@ -545,6 +545,9 @@ func (c *ChainConfig) IsShanghai(num *big.Int, time uint64, currentArbosVersion 
 
 // IsCancun returns whether num is either equal to the Cancun fork time or greater.
 func (c *ChainConfig) IsCancun(num *big.Int, time uint64, currentArbosVersion uint64) bool {
+	if c.IsArbitrum() {
+		return currentArbosVersion >= 20
+	}
 	return c.IsLondon(num) && isTimestampForked(c.CancunTime, time)
 }
 

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -110,7 +110,7 @@ func ArbitrumDevTestParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       11,
+		InitialArbOSVersion:       20,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -120,7 +120,7 @@ func ArbitrumDevTestDASParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       11,
+		InitialArbOSVersion:       20,
 		InitialChainOwner:         common.Address{},
 	}
 }


### PR DESCRIPTION
This also disables the BLOBBASEFEE opcode for Arbitrum chains