### PR TITLE
core/vm, params: ensure order of forks, prevent overflow (#29023)

### DIFF
--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -187,7 +187,12 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc) gasFunc {
 		// outside of this function, as part of the dynamic gas, and that will make it
 		// also become correctly reported to tracers.
 		contract.Gas += coldCost
-		return gas + coldCost, nil
+
+		var overflow bool
+		if gas, overflow = math.SafeAdd(gas, coldCost); overflow {
+			return 0, ErrGasUintOverflow
+		}
+		return gas, nil
 	}
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1408,6 +1408,7 @@ func setupReceiptBackend(t *testing.T, genBlocks int) (*testBackend, []common.Ha
 			tx  *types.Transaction
 			err error
 		)
+		b.SetPoS()
 		switch i {
 		case 0:
 			// transfer 1000wei
@@ -1456,7 +1457,6 @@ func setupReceiptBackend(t *testing.T, genBlocks int) (*testBackend, []common.Ha
 			b.AddTx(tx)
 			txHashes[i] = tx.Hash()
 		}
-		b.SetPoS()
 	})
 	return backend, txHashes
 }

--- a/params/config.go
+++ b/params/config.go
@@ -881,6 +881,8 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 	if chainID == nil {
 		chainID = new(big.Int)
 	}
+	// disallow setting Merge out of order
+	isMerge = isMerge && c.IsLondon(num)
 	return Rules{
 		IsArbitrum:       c.IsArbitrum(),
 		ChainID:          new(big.Int).Set(chainID),
@@ -895,9 +897,9 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
-		IsShanghai:       c.IsShanghai(num, timestamp, currentArbosVersion),
-		IsCancun:         c.IsCancun(num, timestamp, currentArbosVersion),
-		IsPrague:         c.IsPrague(num, timestamp),
-		IsVerkle:         c.IsVerkle(num, timestamp),
+		IsShanghai:       isMerge && c.IsShanghai(num, timestamp, currentArbosVersion),
+		IsCancun:         isMerge && c.IsCancun(num, timestamp, currentArbosVersion),
+		IsPrague:         isMerge && c.IsPrague(num, timestamp),
+		IsVerkle:         isMerge && c.IsVerkle(num, timestamp),
 	}
 }


### PR DESCRIPTION
Closes NIT-2397

This PR fixes an overflow which can could happen if inconsistent blockchain rules were configured. Additionally, it tries to prevent such inconsistencies from occurring by making sure that merge cannot be enabled unless previous fork(s) are also enabled.

(cherry picked from commit ac0ff044606a663eeb47ef60ed5506f842753084) aka https://github.com/ethereum/go-ethereum/pull/29023