### PR TITLE
Fix requested block ahead of current block check

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -535,7 +535,7 @@ func (a *APIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOr
 	hash, ishash := blockNrOrHash.Hash()
 	bc := a.BlockChain()
 	// check if we are not trying to get recent state that is not yet triedb referenced or committed in Blockchain.writeBlockWithState
-	if ishash && header.Number.Cmp(bc.CurrentBlock().Number) > 0 && bc.GetCanonicalHash(header.Number.Uint64()) != hash {
+	if ishash && header != nil && header.Number.Cmp(bc.CurrentBlock().Number) > 0 && bc.GetCanonicalHash(header.Number.Uint64()) != hash {
 		return nil, nil, errors.New("requested block ahead of current block and the hash is not currently canonical")
 	}
 	return a.stateAndHeaderFromHeader(ctx, header, err)


### PR DESCRIPTION
Header could be nil here, so we should check err first. Right now this results in a vague "method handler crashed" error message from the RPC if you eth_call against a header that doesn't exist, instead of the much better "header not found".