### PR TITLE
Fix eth_feeHistory gasUsedRatio

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -282,7 +282,7 @@ func (a *APIBackend) FeeHistory(
 			currentTimestampGasUsed = 0
 		}
 
-		receipts := a.BlockChain().GetReceiptsByHash(header.ReceiptHash)
+		receipts := a.BlockChain().GetReceiptsByHash(header.Hash())
 		for _, receipt := range receipts {
 			if receipt.GasUsed > receipt.GasUsedForL1 {
 				currentTimestampGasUsed += receipt.GasUsed - receipt.GasUsedForL1


### PR DESCRIPTION
The intent for eth_feeHistory for Arbitrum is to return the ratio of gas used per second / the target gas per second. The logic for calculating this gets the receipts for each tx in a block and gets the cumulative gas used, but it was using the wrong hash to look up the receipts (it should be the block hash and not the receipts hash).

Note: the current implementation returns 1.0 for gasUsedRatio for the blocks at the beginning of the window specified by eth_feeHistory's blockCount and newestBlock if the prior block has the same timestamp as the first block in the window (ie time has not ticked over).

# Testing done
Not tested directly. By looking at results of eth_feeHistory on arb1 we can infer from first few blocks gasUsedRatio being 1 and the rest being zero that time is progressing but `currentTimestampGasUsed` must be zero. 

```
$ curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_feeHistory","id":67,"params":["20", "latest", [100.0]]}' https://arb1.arbitrum.io/rpc
{"jsonrpc":"2.0","id":67,"result":{"oldestBlock":"0xc537885","reward":[["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"],["0x0"]],"baseFeePerGas":["0x20e1b98","0x20f09e0","0x2112108","0x212f9b0","0x20f8eb0","0x211ffb0","0x2130950","0x2154b70","0x2145170","0x216f920","0x219faa8","0x2207ea0","0x21ebd68","0x2215578","0x2275888","0x22b8ea8","0x22915d8","0x22c0ba8","0x230af28","0x235cfa8","0x2351428"],"gasUsedRatio":[1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}}
```

The only way for it to be zero is if there were no receipts. By looking at other uses of `Blockchain.GetReceiptsByHash` we can see it's supposed to be the block hash and not the receipts hash https://github.com/OffchainLabs/go-ethereum/blob/master/core/blockchain.go#L725, which would explain zero receipts.