### PR TITLE
Arbitrum APIBackend's GetTransaction should return false when tx is not found

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -614,7 +614,7 @@ func (a *APIBackend) SendConditionalTx(ctx context.Context, signedTx *types.Tran
 
 func (a *APIBackend) GetTransaction(ctx context.Context, txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64, error) {
 	tx, blockHash, blockNumber, index := rawdb.ReadTransaction(a.b.chainDb, txHash)
-	return true, tx, blockHash, blockNumber, index, nil
+	return tx != nil, tx, blockHash, blockNumber, index, nil
 }
 
 func (a *APIBackend) GetPoolTransactions() (types.Transactions, error) {


### PR DESCRIPTION
Resolves NIT-2544