### PR TITLE
Allow lowering of basefee to 0 if vm runs with NoBaseFee flag and 0 gas price

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -83,8 +83,8 @@ type BlockContext struct {
 	Random      *common.Hash   // Provides information for PREVRANDAO
 
 	// Arbitrum information
-	ArbOSVersion uint64
-	BaseFeeCopy  *big.Int // Copy of BaseFee to be used in arbitrum's geth hooks and precompiles when BaseFee is lowered to 0 when vm runs with NoBaseFee flag and 0 gas price. Is nil when BaseFee isn't lowered to 0
+	ArbOSVersion   uint64
+	BaseFeeInBlock *big.Int // Copy of BaseFee to be used in arbitrum's geth hooks and precompiles when BaseFee is lowered to 0 when vm runs with NoBaseFee flag and 0 gas price. Is nil when BaseFee isn't lowered to 0
 }
 
 // TxContext provides the EVM with information about a transaction.
@@ -143,7 +143,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 	// invariants (basefee < feecap)
 	if config.NoBaseFee {
 		if txCtx.GasPrice.BitLen() == 0 {
-			blockCtx.BaseFeeCopy = new(big.Int).Set(blockCtx.BaseFee)
+			blockCtx.BaseFeeInBlock = new(big.Int).Set(blockCtx.BaseFee)
 			blockCtx.BaseFee = new(big.Int)
 		}
 		if txCtx.BlobFeeCap != nil && txCtx.BlobFeeCap.BitLen() == 0 {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -84,6 +84,7 @@ type BlockContext struct {
 
 	// Arbitrum information
 	ArbOSVersion uint64
+	BaseFeeCopy  *big.Int // Copy of BaseFee to be used in arbitrum's geth hooks and precompiles when BaseFee is lowered to 0 when vm runs with NoBaseFee flag and 0 gas price. Is nil when BaseFee isn't lowered to 0
 }
 
 // TxContext provides the EVM with information about a transaction.
@@ -141,8 +142,8 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 	// gas prices were specified, lower the basefee to 0 to avoid breaking EVM
 	// invariants (basefee < feecap)
 	if config.NoBaseFee {
-		// Currently we don't set block context's BaseFee to zero, since nitro uses this field
-		if txCtx.GasPrice.BitLen() == 0 && !chainConfig.IsArbitrum() {
+		if txCtx.GasPrice.BitLen() == 0 {
+			blockCtx.BaseFeeCopy = new(big.Int).Set(blockCtx.BaseFee)
 			blockCtx.BaseFee = new(big.Int)
 		}
 		if txCtx.BlobFeeCap != nil && txCtx.BlobFeeCap.BitLen() == 0 {


### PR DESCRIPTION
Related to NIT-2412

Introduce `BaseFeeCopy` field in vm.BlockContext to persist BaseFee value when its lowered to 0 to preserve EVM invariant `basefee < feecap` in cases vm is run with NoBaseFee flag and 0 gas price. 

This enables nitro to use persisted basefee value in TxProcessor hooks and ArbGasInfo precompile during eth_call, eth_estimateGas, etc

Pulled in by:-https://github.com/OffchainLabs/nitro/pull/2358