### PR TITLE
Improve pruning: performance, config and progress logging 

### DIFF
--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -385,7 +385,10 @@ func dumpRawTrieDescendants(db ethdb.Database, root common.Hash, output *stateBl
 				output.Put(data.CodeHash, nil)
 			}
 			if data.Root != (common.Hash{}) {
-				storageTr, err := trie.NewStateTrie(trie.StorageTrieID(root, key, data.Root), sdb.TrieDB())
+				// note: we are passing data.Root as stateRoot here, to skip the check for stateRoot existence in trie.newTrieReader,
+				// we already check that when opening state trie and reading the account node
+				trieID := trie.StorageTrieID(data.Root, key, data.Root)
+				storageTr, err := trie.NewStateTrie(trieID, sdb.TrieDB())
 				if err != nil {
 					return err
 				}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -140,7 +140,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	// Try to recover offline state pruning only in hash-based.
 	if scheme == rawdb.HashScheme {
-		if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb); err != nil {
+		if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb, 1); err != nil {
 			log.Error("Failed to recover state", "error", err)
 		}
 	}


### PR DESCRIPTION
part of NIT-2541

This PR:
* reintroduces performance improvement previously removed while fixing upstream geth merge
```
// note: we are passing data.Root as stateRoot here, to skip the check for stateRoot existence in trie.newTrieReader,
// we already check that when opening state trie and reading the account node
trieID := trie.StorageTrieID(data.Root, key, data.Root)
storageTr, err := trie.NewStateTrie(trieID, sdb.TrieDB())
```

* enables cleans cache in triedb used for traversing storage tries in `dumpRawTrieDescendants` - when opening storage trie with `trie.NewStateTrie` (using the trick above), a node with hash equal `data.Root` is read twice from triedb (once in when getting a `trie.Reader`, then when reading the node). Caching the node should save some of KeyValueStore reads.

* adds `pruner.Config.Threads` option

* adds extra progress logging when a thread traversing storage trie for given account takes longer then 5 minutes


