### PR TITLE
Exposes CacheConfig.triedbConfig

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -158,6 +158,11 @@ type CacheConfig struct {
 	SnapshotWait    bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
 
+// arbitrum: exposing CacheConfig.triedbConfig to be used by Nitro when initializing arbos in database
+func (c *CacheConfig) TriedbConfig() *trie.Config {
+	return c.triedbConfig()
+}
+
 // triedbConfig derives the configures for trie database.
 func (c *CacheConfig) triedbConfig() *trie.Config {
 	config := &trie.Config{Preimages: c.Preimages}


### PR DESCRIPTION
Exposes CacheConfig.triedbConfig to be used by Nitro when initializing arbos in database.

Addresses this PR change request: https://github.com/OffchainLabs/nitro/pull/2324#discussion_r1631308688