### PR TITLE
Switch merge checks action to pull_request_target event

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -1,7 +1,7 @@
 name: Merge Checks
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
     types: [synchronize, opened, reopened, labeled, unlabeled]
 


### PR DESCRIPTION
This is a copy of https://github.com/OffchainLabs/nitro/pull/2477 for the geth repo. This should allow the check to run on 3rd party PRs from forks. CI will need bypassed to merge this, as the "design approved check" won't appear, because pull_request_target only runs when it's on the base branch.