### PR TITLE
Add a notion of zombies to preserve empty account behavior

### DIFF
--- a/core/state/journal_arbitrum_test.go
+++ b/core/state/journal_arbitrum_test.go
@@ -1,0 +1,14 @@
+package state
+
+import "testing"
+
+func TestIsZombie(t *testing.T) {
+	var nonZombie journalEntry = createObjectChange{}
+	if isZombie(nonZombie) {
+		t.Error("createObjectChange should not be a zombie")
+	}
+	var zombie journalEntry = createZombieChange{}
+	if !isZombie(zombie) {
+		t.Error("createZombieChange should be a zombie")
+	}
+}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -440,7 +440,6 @@ func (s *StateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tr
 	if amount.IsZero() && s.getStateObject(addr) == nil {
 		if _, destructed := s.stateObjectsDestruct[addr]; destructed {
 			s.createZombie(addr)
-			return
 		}
 	}
 	stateObject := s.getOrNewStateObject(addr)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -438,8 +438,10 @@ func (s *StateDB) AddBalance(addr common.Address, amount *uint256.Int, reason tr
 func (s *StateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) {
 	// Arbitrum: this behavior created empty accounts in old geth versions.
 	if amount.IsZero() && s.getStateObject(addr) == nil {
-		s.createZombie(addr)
-		return
+		if _, destructed := s.stateObjectsDestruct[addr]; destructed {
+			s.createZombie(addr)
+			return
+		}
 	}
 	stateObject := s.getOrNewStateObject(addr)
 	if stateObject != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -436,12 +436,6 @@ func (s *StateDB) AddBalance(addr common.Address, amount *uint256.Int, reason tr
 
 // SubBalance subtracts amount from the account associated with addr.
 func (s *StateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) {
-	// Arbitrum: this behavior created empty accounts in old geth versions.
-	if amount.IsZero() && s.getStateObject(addr) == nil {
-		if _, destructed := s.stateObjectsDestruct[addr]; destructed {
-			s.createZombie(addr)
-		}
-	}
 	stateObject := s.getOrNewStateObject(addr)
 	if stateObject != nil {
 		s.arbExtraData.unexpectedBalanceDelta.Sub(s.arbExtraData.unexpectedBalanceDelta, amount.ToBig())

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -134,6 +134,15 @@ func (s *StateDB) AddStylusPagesEver(new uint16) {
 	s.arbExtraData.everWasmPages = common.SaturatingUAdd(s.arbExtraData.everWasmPages, new)
 }
 
+// Arbitrum: certain behavior created empty accounts in old geth versions.
+func (s *StateDB) CreateZombieIfDeleted(addr common.Address) {
+	if s.getStateObject(addr) == nil {
+		if _, destructed := s.stateObjectsDestruct[addr]; destructed {
+			s.createZombie(addr)
+		}
+	}
+}
+
 func NewDeterministic(root common.Hash, db Database) (*StateDB, error) {
 	sdb, err := New(root, db, nil)
 	if err != nil {

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -134,7 +134,7 @@ func (s *StateDB) AddStylusPagesEver(new uint16) {
 	s.arbExtraData.everWasmPages = common.SaturatingUAdd(s.arbExtraData.everWasmPages, new)
 }
 
-// Arbitrum: certain behavior created empty accounts in old geth versions.
+// Arbitrum: preserve empty account behavior from old geth and ArbOS versions.
 func (s *StateDB) CreateZombieIfDeleted(addr common.Address) {
 	if s.getStateObject(addr) == nil {
 		if _, destructed := s.stateObjectsDestruct[addr]; destructed {

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -44,6 +44,9 @@ type StateDB interface {
 	AddStylusPages(new uint16) (uint16, uint16)
 	AddStylusPagesEver(new uint16)
 
+	// Arbitrum: preserve old empty account behavior
+	CreateZombieIfDeleted(common.Address)
+
 	Deterministic() bool
 	Database() state.Database
 


### PR DESCRIPTION
Points into https://github.com/OffchainLabs/go-ethereum/pull/346

Geth statedb changes in v1.14.2 mean that the old behavior of SubBalance amount 0 in respect to empty accounts has changed. This PR adds back in the old behavior using a notion of zombies.

Requires https://github.com/OffchainLabs/nitro/pull/2732 for the new method to be used on the nitro side