### PR TITLE
Filter transaction

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -77,7 +77,8 @@ func (m *mutation) isDelete() bool {
 type arbFiltered int
 
 const (
-	txFiltered arbFiltered = 1 + iota
+	unFiltered arbFiltered = iota
+	txFiltered
 	blockFiltered
 )
 
@@ -231,7 +232,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 }
 
 func (s *StateDB) FilterTx(withBlock bool) {
-	if s.arbTxFilter == 0 {
+	if s.arbTxFilter == unFiltered {
 		s.arbTxFilter = txFiltered
 		if withBlock {
 			s.arbTxFilter = blockFiltered
@@ -860,7 +861,7 @@ func (s *StateDB) RevertToSnapshot(revid int) {
 	snapshot := revision.journalIndex
 	s.arbExtraData.unexpectedBalanceDelta = new(big.Int).Set(revision.unexpectedBalanceDelta)
 	if s.arbTxFilter == txFiltered {
-		s.arbTxFilter = 0
+		s.arbTxFilter = unFiltered
 	}
 
 	// Replay the journal to undo changes and remove invalidated snapshots

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -51,7 +51,6 @@ type revision struct {
 
 	// Arbitrum: track the total balance change across all accounts
 	unexpectedBalanceDelta *big.Int
-	arbTxFilter            bool
 }
 
 type mutationType int
@@ -222,6 +221,10 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 
 func (s *StateDB) FilterTx() {
 	s.arbExtraData.arbTxFilter = true
+}
+
+func (s *StateDB) ClearTxFilter() {
+	s.arbExtraData.arbTxFilter = false
 }
 
 func (s *StateDB) IsTxFiltered() bool {
@@ -829,7 +832,7 @@ func (s *StateDB) Copy() *StateDB {
 func (s *StateDB) Snapshot() int {
 	id := s.nextRevisionId
 	s.nextRevisionId++
-	s.validRevisions = append(s.validRevisions, revision{id, s.journal.length(), new(big.Int).Set(s.arbExtraData.unexpectedBalanceDelta), s.arbExtraData.arbTxFilter})
+	s.validRevisions = append(s.validRevisions, revision{id, s.journal.length(), new(big.Int).Set(s.arbExtraData.unexpectedBalanceDelta)})
 	return id
 }
 
@@ -845,7 +848,6 @@ func (s *StateDB) RevertToSnapshot(revid int) {
 	revision := s.validRevisions[idx]
 	snapshot := revision.journalIndex
 	s.arbExtraData.unexpectedBalanceDelta = new(big.Int).Set(revision.unexpectedBalanceDelta)
-	s.arbExtraData.arbTxFilter = revision.arbTxFilter
 
 	// Replay the journal to undo changes and remove invalidated snapshots
 	s.journal.revert(s, snapshot)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -77,7 +77,7 @@ func (m *mutation) isDelete() bool {
 type arbFiltered int
 
 const (
-	unFiltered arbFiltered = iota
+	notFiltered arbFiltered = iota
 	txFiltered
 	blockFiltered
 )
@@ -232,7 +232,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 }
 
 func (s *StateDB) FilterTx(withBlock bool) {
-	if s.arbTxFilter == unFiltered {
+	if s.arbTxFilter == notFiltered {
 		s.arbTxFilter = txFiltered
 		if withBlock {
 			s.arbTxFilter = blockFiltered
@@ -861,7 +861,7 @@ func (s *StateDB) RevertToSnapshot(revid int) {
 	snapshot := revision.journalIndex
 	s.arbExtraData.unexpectedBalanceDelta = new(big.Int).Set(revision.unexpectedBalanceDelta)
 	if s.arbTxFilter == txFiltered {
-		s.arbTxFilter = unFiltered
+		s.arbTxFilter = notFiltered
 	}
 
 	// Replay the journal to undo changes and remove invalidated snapshots

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -842,9 +842,6 @@ func (s *StateDB) Copy() *StateDB {
 
 // Snapshot returns an identifier for the current revision of the state.
 func (s *StateDB) Snapshot() int {
-	if s.arbTxFilter == txFiltered {
-		panic("trying to create a new snapshot when the previous transaction applied to this state was filtered. RevertToSnapshot should be called before moving on to the next transaction")
-	}
 	id := s.nextRevisionId
 	s.nextRevisionId++
 	s.validRevisions = append(s.validRevisions, revision{id, s.journal.length(), new(big.Int).Set(s.arbExtraData.unexpectedBalanceDelta)})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -230,7 +230,7 @@ func (s *StateDB) FilterTx(withBlock bool) {
 	}
 }
 
-func (s *StateDB) IsTxValid() bool {
+func (s *StateDB) IsTxInvalid() bool {
 	return s.arbTxFilter == 1
 }
 

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -164,6 +164,8 @@ func (s *StateDB) Deterministic() bool {
 	return s.deterministic
 }
 
+var ErrArbTxFilter error = errors.New("internal error")
+
 type ArbitrumExtraData struct {
 	unexpectedBalanceDelta *big.Int                      // total balance change across all accounts
 	userWasms              UserWasms                     // user wasms encountered during execution
@@ -171,6 +173,7 @@ type ArbitrumExtraData struct {
 	everWasmPages          uint16                        // largest number of pages ever allocated during this tx's execution
 	activatedWasms         map[common.Hash]ActivatedWasm // newly activated WASMs
 	recentWasms            RecentWasms
+	arbTxFilter            bool
 }
 
 func (s *StateDB) SetArbFinalizer(f func(*ArbitrumExtraData)) {

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -50,7 +50,7 @@ type StateDB interface {
 
 	// Arbitrum
 	FilterTx(bool)
-	IsTxInvalid() bool
+	IsTxFiltered() bool
 
 	Deterministic() bool
 	Database() state.Database

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -48,6 +48,10 @@ type StateDB interface {
 	// Arbitrum: preserve old empty account behavior
 	CreateZombieIfDeleted(common.Address)
 
+	// Arbitrum
+	FilterTx(bool)
+	IsTxValid() bool
+
 	Deterministic() bool
 	Database() state.Database
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -50,6 +50,7 @@ type StateDB interface {
 
 	// Arbitrum
 	FilterTx()
+	ClearTxFilter()
 	IsTxFiltered() bool
 
 	Deterministic() bool

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -49,7 +49,7 @@ type StateDB interface {
 	CreateZombieIfDeleted(common.Address)
 
 	// Arbitrum
-	FilterTx(bool)
+	FilterTx()
 	IsTxFiltered() bool
 
 	Deterministic() bool

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -50,7 +50,7 @@ type StateDB interface {
 
 	// Arbitrum
 	FilterTx(bool)
-	IsTxValid() bool
+	IsTxInvalid() bool
 
 	Deterministic() bool
 	Database() state.Database


### PR DESCRIPTION
This PR enables filtering of malicious transactions and blocks via a `stateDB` object

Corresponding Nitro PR- https://github.com/OffchainLabs/nitro/pull/2807
Part of NIT-2848