### PR TITLE
Merge v1.14.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,23 +102,14 @@ jobs:
       dist: noble
       go: 1.22.x
       script:
-        - travis_wait 30 go run build/ci.go test $TEST_PACKAGES
-
-    - stage: build
-      if: type = pull_request
-      os: linux
-      arch: arm64
-      dist: noble
-      go: 1.21.x
-      script:
-        - travis_wait 30 go run build/ci.go test $TEST_PACKAGES
+        - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
 
     - stage: build
       os: linux
       dist: noble
       go: 1.21.x
       script:
-        - travis_wait 30 go run build/ci.go test $TEST_PACKAGES
+        - travis_wait 45 go run build/ci.go test $TEST_PACKAGES
 
     # This builder does the Ubuntu PPA nightly uploads
     - stage: build
@@ -131,7 +122,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install devscripts debhelper dput fakeroot python-bzrlib python-paramiko
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install devscripts debhelper dput fakeroot
       script:
         - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
         - go run build/ci.go debsrc -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
@@ -156,4 +147,4 @@ jobs:
       dist: noble
       go: 1.22.x
       script:
-        - travis_wait 30 go run build/ci.go test  -race $TEST_PACKAGES
+        - travis_wait 50 go run build/ci.go test  -race $TEST_PACKAGES

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 14         // Minor version component of the current release
-	VersionPatch = 3          // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 14       // Minor version component of the current release
+	VersionPatch = 3        // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 14       // Minor version component of the current release
-	VersionPatch = 2        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 14         // Minor version component of the current release
+	VersionPatch = 3          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
fixes: NIT-2677

Merge upstream geth's v1.14.3 release into our geth fork:https://github.com/ethereum/go-ethereum/releases/tag/v1.14.3

nitro PR- https://github.com/OffchainLabs/nitro/pull/2806

# Testing done
geth and nitro tests pass
