### PR TITLE
Revert accidental change to tipReceipient

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -523,7 +523,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	} else {
 		fee := new(uint256.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTipU256)
-		st.state.AddBalance(st.evm.Context.Coinbase, fee, tracing.BalanceIncreaseRewardTransactionFee)
+		st.state.AddBalance(tipReceipient, fee, tracing.BalanceIncreaseRewardTransactionFee)
 		tipAmount = fee.ToBig()
 	}
 


### PR DESCRIPTION
This was accidentally changed in the geth v1.14.0 merge. It doesn't matter as far as the actual balances go because the tip in Arbitrum is always zero, but it does matter in terms of state accessed by the replay binary and the validator providing that state.