### PR TITLE
Fix Typo in `backend.go

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -446,7 +446,7 @@ func (s *Ethereum) SyncMode() downloader.SyncMode {
 	// the head state, forcefully rerun the snap sync. Note it doesn't mean the
 	// persistent state is corrupted, just mismatch with the head block.
 	if !s.blockchain.HasState(head.Root) {
-		log.Info("Reenabled snap sync as chain is stateless")
+		log.Info("Re-enabled snap sync as chain is stateless")
 		return downloader.SnapSync
 	}
 	// Nope, we're really full syncing


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `backend.go`**

## Description  
This pull request corrects a typo in the `backend.go` file. The word "Reenabled" has been corrected to "Re-enabled" to improve clarity and maintain correct spelling.

### Changes Made:
- **File Modified:** `backend.go`
- **Summary of Changes:**  
  - Corrected the typo from "Reenabled" to "Re-enabled" in the logging message.

## Checklist  
- [x] Fixed the typo in the file.
- [x] Verified that this change doesn't break any functionality.

## Additional Notes  
This change ensures the logging message maintains proper spelling and readability.

---

**Allow edits by maintainers:** [x]
