### PR TITLE
Fix Typo in `blobpool.go`

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -798,7 +798,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	p.state = statedb
 
 	// Run the reorg between the old and new head and figure out which accounts
-	// need to be rechecked and which transactions need to be readded
+	// need to be rechecked and which transactions need to be re-added
 	if reinject, inclusions := p.reorg(oldHead, newHead); reinject != nil {
 		var adds []*types.Transaction
 		for addr, txs := range reinject {


### PR DESCRIPTION
# Fix Typo in `blobpool.go`

## Description
This pull request corrects a minor typo in the `blobpool.go` file. The fix ensures clarity and consistency in the code comments.

**Before**:
- `readded`

**After**:
- `re-added`

## References (if applicable)
- N/A

## Checklist
- [x] Typo corrected in `blobpool.go`
- [ ] Documentation updated (if applicable)
- [ ] Tests added/updated (if applicable)
