### PR TITLE
Improves triedb metrics

### DIFF
--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -401,7 +401,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	memcacheFlushBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.dirties)))
 
-	log.Info("Persisted nodes from memory database", "nodes", nodes, "dirtiesnodes", len(db.dirties), "storagesize", storage, "dirtiessize", db.dirtiesSize, "time", time.Since(start),
+	log.Info("Persisted nodes from memory database", "nodes", nodes-len(db.dirties), "size", storage-db.dirtiesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
 
 	return nil

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -455,6 +455,7 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	}
 	logger("Persisted trie from memory database", "nodes", nodes-len(db.dirties)+int(db.flushnodes), "size", storage-db.dirtiesSize+db.flushsize, "time", time.Since(start)+db.flushtime,
 		"gcnodes", db.gcnodes, "gcsize", db.gcsize, "gctime", db.gctime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
+	logger("Persisted trie from memory database", "time_since_start", time.Since(start))
 
 	// Reset the garbage collection statistics
 	db.gcnodes, db.gcsize, db.gctime = 0, 0, 0

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -401,7 +401,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	memcacheFlushBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.dirties)))
 
-	log.Debug("Persisted nodes from memory database", "nodes", nodes-len(db.dirties), "size", storage-db.dirtiesSize, "time", time.Since(start),
+	log.Info("Persisted nodes from memory database", "nodes", nodes-len(db.dirties), "size", storage-db.dirtiesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
 
 	return nil

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -58,8 +58,8 @@ var (
 	memcacheCommitNodesMeter = metrics.NewRegisteredMeter("hashdb/memcache/commit/nodes", nil)
 	memcacheCommitBytesMeter = metrics.NewRegisteredMeter("hashdb/memcache/commit/bytes", nil)
 
-	arbMemcacheFlushTimer  = metrics.NewRegisteredTimer("arb/hashdb/memcache/flush/time", nil)
-	arbMemcacheCommitTimer = metrics.NewRegisteredTimer("arb/hashdb/memcache/commit/time", nil)
+	memcacheFlushStandardTimer  = metrics.NewRegisteredTimer("hashdb/memcache/flush/standardtime", nil)
+	memcacheCommitStandardTimer = metrics.NewRegisteredTimer("hashdb/memcache/commit/standardtime", nil)
 )
 
 // ChildResolver defines the required method to decode the provided
@@ -404,7 +404,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	memcacheFlushBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.dirties)))
 
-	arbMemcacheFlushTimer.Update(time.Since(start))
+	memcacheFlushStandardTimer.Update(time.Since(start))
 
 	log.Info("Persisted nodes from memory database", "nodes", nodes-len(db.dirties), "size", storage-db.dirtiesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
@@ -454,7 +454,7 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	memcacheCommitBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheCommitNodesMeter.Mark(int64(nodes - len(db.dirties)))
 
-	arbMemcacheCommitTimer.Update(time.Since(start))
+	memcacheCommitStandardTimer.Update(time.Since(start))
 
 	logger := log.Info
 	if !report {

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -453,9 +453,8 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	if !report {
 		logger = log.Debug
 	}
-	logger("Persisted trie from memory database", "nodes", nodes-len(db.dirties)+int(db.flushnodes), "size", storage-db.dirtiesSize+db.flushsize, "time", time.Since(start)+db.flushtime,
+	logger("Persisted trie from memory database", "nodes", nodes, "dirtiesnodes", len(db.dirties), "flushnodes", int(db.flushnodes), "storagesize", storage, "dirtiessize", db.dirtiesSize, "flushsize", db.flushsize, "time", time.Since(start), "flushtime", db.flushtime,
 		"gcnodes", db.gcnodes, "gcsize", db.gcsize, "gctime", db.gctime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
-	logger("Persisted trie from memory database", "time_since_start", time.Since(start))
 
 	// Reset the garbage collection statistics
 	db.gcnodes, db.gcsize, db.gctime = 0, 0, 0

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -453,7 +453,7 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	if !report {
 		logger = log.Debug
 	}
-	logger("Persisted trie from memory database", "nodes", nodes, "dirtiesnodes", len(db.dirties), "flushnodes", int(db.flushnodes), "storagesize", storage, "dirtiessize", db.dirtiesSize, "flushsize", db.flushsize, "time", time.Since(start), "flushtime", db.flushtime,
+	logger("Persisted trie from memory database", "nodes", nodes-len(db.dirties), "flushnodes", db.flushnodes, "size", storage-db.dirtiesSize, "flushsize", db.flushsize, "time", time.Since(start), "flushtime", db.flushtime,
 		"gcnodes", db.gcnodes, "gcsize", db.gcsize, "gctime", db.gctime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
 
 	// Reset the garbage collection statistics

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -46,7 +46,7 @@ var (
 	memcacheDirtyReadMeter  = metrics.NewRegisteredMeter("hashdb/memcache/dirty/read", nil)
 	memcacheDirtyWriteMeter = metrics.NewRegisteredMeter("hashdb/memcache/dirty/write", nil)
 
-	memcacheFlushTimeTimer  = metrics.NewRegisteredResettingTimer("hashdb/memcache/flush/time", nil)
+	memcacheFlushTimeTimer  = metrics.NewRegisteredTimer("hashdb/memcache/flush/time", nil)
 	memcacheFlushNodesMeter = metrics.NewRegisteredMeter("hashdb/memcache/flush/nodes", nil)
 	memcacheFlushBytesMeter = metrics.NewRegisteredMeter("hashdb/memcache/flush/bytes", nil)
 
@@ -54,12 +54,9 @@ var (
 	memcacheGCNodesMeter = metrics.NewRegisteredMeter("hashdb/memcache/gc/nodes", nil)
 	memcacheGCBytesMeter = metrics.NewRegisteredMeter("hashdb/memcache/gc/bytes", nil)
 
-	memcacheCommitTimeTimer  = metrics.NewRegisteredResettingTimer("hashdb/memcache/commit/time", nil)
+	memcacheCommitTimeTimer  = metrics.NewRegisteredTimer("hashdb/memcache/commit/time", nil)
 	memcacheCommitNodesMeter = metrics.NewRegisteredMeter("hashdb/memcache/commit/nodes", nil)
 	memcacheCommitBytesMeter = metrics.NewRegisteredMeter("hashdb/memcache/commit/bytes", nil)
-
-	memcacheFlushStandardTimer  = metrics.NewRegisteredTimer("hashdb/memcache/flush/standardtime", nil)
-	memcacheCommitStandardTimer = metrics.NewRegisteredTimer("hashdb/memcache/commit/standardtime", nil)
 )
 
 // ChildResolver defines the required method to decode the provided
@@ -404,8 +401,6 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	memcacheFlushBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.dirties)))
 
-	memcacheFlushStandardTimer.Update(time.Since(start))
-
 	log.Info("Persisted nodes from memory database", "nodes", nodes-len(db.dirties), "size", storage-db.dirtiesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
 
@@ -453,8 +448,6 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	memcacheCommitTimeTimer.Update(time.Since(start))
 	memcacheCommitBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheCommitNodesMeter.Mark(int64(nodes - len(db.dirties)))
-
-	memcacheCommitStandardTimer.Update(time.Since(start))
 
 	logger := log.Info
 	if !report {

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -401,7 +401,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	memcacheFlushBytesMeter.Mark(int64(storage - db.dirtiesSize))
 	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.dirties)))
 
-	log.Info("Persisted nodes from memory database", "nodes", nodes-len(db.dirties), "size", storage-db.dirtiesSize, "time", time.Since(start),
+	log.Info("Persisted nodes from memory database", "nodes", nodes, "dirtiesnodes", len(db.dirties), "storagesize", storage, "dirtiessize", db.dirtiesSize, "time", time.Since(start),
 		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.dirties), "livesize", db.dirtiesSize)
 
 	return nil


### PR DESCRIPTION
Related to NIT-3047

- Logs "Persisted nodes from memory database" in hashdb's Cap as Info instead of Debug.
- Logs how long it takes to run a single hashdb Commit call
- Uses Timer instead of ResettingTimer for metrics related to flush and commit operations. It is not straightforward to use ResettingTimers to infer a per operation metric