### PR TITLE
Optimize destroying an account with no storage in snapshot diffToDisk

### DIFF
--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -85,10 +85,8 @@ func (dl *diskLayer) account(hash common.Hash, ignoreStale bool) (*types.SlimAcc
 		return nil, nil
 	}
 	account := new(types.SlimAccount)
-	if err := rlp.DecodeBytes(data, account); err != nil {
-		panic(err)
-	}
-	return account, nil
+	err = rlp.DecodeBytes(data, account)
+	return account, err
 }
 
 // AccountRLP directly retrieves the account RLP associated with a particular

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -76,8 +76,8 @@ func (dl *diskLayer) Stale() bool {
 
 // Account directly retrieves the account associated with a particular hash in
 // the snapshot slim data format.
-func (dl *diskLayer) account(hash common.Hash, ignoreStale bool) (*types.SlimAccount, error) {
-	data, err := dl.accountRLP(hash, ignoreStale)
+func (dl *diskLayer) account(hash common.Hash, evenIfStale bool) (*types.SlimAccount, error) {
+	data, err := dl.accountRLP(hash, evenIfStale)
 	if err != nil {
 		return nil, err
 	}
@@ -91,13 +91,13 @@ func (dl *diskLayer) account(hash common.Hash, ignoreStale bool) (*types.SlimAcc
 
 // AccountRLP directly retrieves the account RLP associated with a particular
 // hash in the snapshot slim data format.
-func (dl *diskLayer) accountRLP(hash common.Hash, ignoreStale bool) ([]byte, error) {
+func (dl *diskLayer) accountRLP(hash common.Hash, evenIfStale bool) ([]byte, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
 	// If the layer was flattened into, consider it invalid (any live reference to
 	// the original should be marked as unusable).
-	if dl.stale && !ignoreStale {
+	if dl.stale && !evenIfStale {
 		return nil, ErrSnapshotStale
 	}
 	// If the layer is being generated, ensure the requested hash has already been

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -76,8 +76,8 @@ func (dl *diskLayer) Stale() bool {
 
 // Account directly retrieves the account associated with a particular hash in
 // the snapshot slim data format.
-func (dl *diskLayer) Account(hash common.Hash) (*types.SlimAccount, error) {
-	data, err := dl.AccountRLP(hash)
+func (dl *diskLayer) account(hash common.Hash, ignoreStale bool) (*types.SlimAccount, error) {
+	data, err := dl.accountRLP(hash, ignoreStale)
 	if err != nil {
 		return nil, err
 	}
@@ -93,13 +93,13 @@ func (dl *diskLayer) Account(hash common.Hash) (*types.SlimAccount, error) {
 
 // AccountRLP directly retrieves the account RLP associated with a particular
 // hash in the snapshot slim data format.
-func (dl *diskLayer) AccountRLP(hash common.Hash) ([]byte, error) {
+func (dl *diskLayer) accountRLP(hash common.Hash, ignoreStale bool) ([]byte, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
 	// If the layer was flattened into, consider it invalid (any live reference to
 	// the original should be marked as unusable).
-	if dl.stale {
+	if dl.stale && !ignoreStale {
 		return nil, ErrSnapshotStale
 	}
 	// If the layer is being generated, ensure the requested hash has already been
@@ -121,7 +121,9 @@ func (dl *diskLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	dl.cache.Set(hash[:], blob)
+	if !dl.stale {
+		dl.cache.Set(hash[:], blob)
+	}
 
 	snapshotCleanAccountMissMeter.Mark(1)
 	if n := len(blob); n > 0 {
@@ -130,6 +132,14 @@ func (dl *diskLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 		snapshotCleanAccountInexMeter.Mark(1)
 	}
 	return blob, nil
+}
+
+func (dl *diskLayer) Account(hash common.Hash) (*types.SlimAccount, error) {
+	return dl.account(hash, false)
+}
+
+func (dl *diskLayer) AccountRLP(hash common.Hash) ([]byte, error) {
+	return dl.accountRLP(hash, false)
 }
 
 // Storage directly retrieves the storage data associated with a particular hash,

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -568,7 +568,10 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		rawdb.DeleteAccountSnapshot(batch, hash)
 		base.cache.Set(hash[:], nil)
 
-		if err == nil && (oldAccount == nil || oldAccount.Root == nil) {
+		if err != nil {
+			log.Warn("Failed to get destructed account from snapshot", "err", err)
+			// Fall through to deleting storage in case this account has any
+		} else if oldAccount == nil || oldAccount.Root == nil {
 			// There's no storage associated with this account to delete
 			continue
 		}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -565,12 +565,13 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			continue
 		}
 
+		oldAccount, err := base.account(hash, true)
+
 		// Delete the account snapshot
 		rawdb.DeleteAccountSnapshot(batch, hash)
 		base.cache.Set(hash[:], nil)
 
 		// Try to check if there's any associated storage to delete from the snapshot
-		oldAccount, err := base.account(hash, true)
 		if err != nil {
 			log.Warn("Failed to get destructed account from snapshot", "err", err)
 			// Fall through to deleting storage in case this account has any


### PR DESCRIPTION
To do this, we get the account info from the disk layer and check if its storage root was empty before trying to iterate over its storage to delete it.