### PR TITLE
Avoid a race in the SimulatedBeacon Stop call

### DIFF
--- a/eth/catalyst/simulated_beacon_api.go
+++ b/eth/catalyst/simulated_beacon_api.go
@@ -71,6 +71,10 @@ func (a *simulatedBeaconAPI) loop() {
 					break
 				}
 				a.sim.Commit()
+				// Avoid a race condition where tx pool is terminated during Commit.
+				if err := a.sim.eth.TxPool().Sync(); err != nil {
+					break
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
The go routine which is responsible for committing blocks was spewing our errors in a spinLoop because it was continuing to call Commit when the txPool was already terminated.

This could cause intense i/o and lead to VSCode hanging, or CI being unable to process the logs.