### PR TITLE
Introduce Arbitrum_40

### DIFF
--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -36,6 +36,7 @@ const ArbosVersion_20 = uint64(20)
 const ArbosVersion_30 = uint64(30)
 const ArbosVersion_31 = uint64(31)
 const ArbosVersion_32 = uint64(32)
+const ArbosVersion_40 = uint64(40)
 
 const ArbosVersion_FixRedeemGas = ArbosVersion_11
 const ArbosVersion_Stylus = ArbosVersion_30


### PR DESCRIPTION
This just creates the concept of an arbos 40 release. The variable is actually used in the `nitro` repository, for example, to initialize ArbOwner storage that hold the toggle for the EIP-7623 call data price increase conditionally.

Part of: NIT-3139