### PR TITLE
Remove the MaxBlobGasPerBlock RPC methods

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -356,10 +356,6 @@ func (a *APIBackend) BlobBaseFee(ctx context.Context) *big.Int {
 	return nil
 }
 
-func (a *APIBackend) MaxBlobGasPerBlock(ctx context.Context) uint64 {
-	return eip4844.MaxBlobGasPerBlock(a.ChainConfig(), a.CurrentHeader().Time)
-}
-
 func (a *APIBackend) ChainDb() ethdb.Database {
 	return a.dbForAPICalls
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -383,10 +383,6 @@ func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) *big.Int {
 	return nil
 }
 
-func (b *EthAPIBackend) MaxBlobGasPerBlock(ctx context.Context) uint64 {
-	return eip4844.MaxBlobGasPerBlock(b.ChainConfig(), b.CurrentHeader().Time)
-}
-
 func (b *EthAPIBackend) ChainDb() ethdb.Database {
 	return b.eth.ChainDb()
 }

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -607,15 +607,6 @@ func (ec *Client) BlobBaseFee(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
-// MaxBlobGasPerBlock retrieves the maximum gas limit per block for blob transactions.
-func (ec *Client) MaxBlobGasPerBlock(ctx context.Context) (uint64, error) {
-	var res uint64
-	if err := ec.c.CallContext(ctx, &res, "eth_maxBlobGasPerBlock"); err != nil {
-		return 0, err
-	}
-	return res, nil
-}
-
 type feeHistoryResultMarshaling struct {
 	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
 	Reward       [][]*hexutil.Big `json:"reward,omitempty"`

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -145,11 +145,6 @@ func (api *EthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
 	return (*hexutil.Big)(api.b.BlobBaseFee(ctx))
 }
 
-// MaxBlobGasPerBlock returns the maximum blob gas per block at the current head.
-func (api *EthereumAPI) MaxBlobGasPerBlock(ctx context.Context) uint64 {
-	return api.b.MaxBlobGasPerBlock(ctx)
-}
-
 // Syncing returns false in case the node is currently not syncing with the network. It can be up-to-date or has not
 // yet received the latest block headers from its peers. In case it is synchronizing:
 // - startingBlock: block number this node started to synchronize from

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -480,16 +480,15 @@ func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil, nil, nil
 }
-func (b testBackend) BlobBaseFee(ctx context.Context) *big.Int      { return new(big.Int) }
-func (b testBackend) MaxBlobGasPerBlock(ctx context.Context) uint64 { return 0 }
-func (b testBackend) ChainDb() ethdb.Database                       { return b.db }
-func (b testBackend) AccountManager() *accounts.Manager             { return b.accman }
-func (b testBackend) ExtRPCEnabled() bool                           { return false }
-func (b testBackend) RPCGasCap() uint64                             { return 10000000 }
-func (b testBackend) RPCEVMTimeout() time.Duration                  { return time.Second }
-func (b testBackend) RPCTxFeeCap() float64                          { return 0 }
-func (b testBackend) UnprotectedAllowed() bool                      { return false }
-func (b testBackend) SetHead(number uint64)                         {}
+func (b testBackend) BlobBaseFee(ctx context.Context) *big.Int { return new(big.Int) }
+func (b testBackend) ChainDb() ethdb.Database                  { return b.db }
+func (b testBackend) AccountManager() *accounts.Manager        { return b.accman }
+func (b testBackend) ExtRPCEnabled() bool                      { return false }
+func (b testBackend) RPCGasCap() uint64                        { return 10000000 }
+func (b testBackend) RPCEVMTimeout() time.Duration             { return time.Second }
+func (b testBackend) RPCTxFeeCap() float64                     { return 0 }
+func (b testBackend) UnprotectedAllowed() bool                 { return false }
+func (b testBackend) SetHead(number uint64)                    {}
 func (b testBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber {
 		return b.chain.CurrentBlock(), nil

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -49,7 +49,6 @@ type Backend interface {
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
 	BlobBaseFee(ctx context.Context) *big.Int
-	MaxBlobGasPerBlock(ctx context.Context) uint64
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -317,8 +317,7 @@ func (b *backendMock) setFork(fork string) error {
 func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }
-func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int      { return big.NewInt(42) }
-func (b *backendMock) MaxBlobGasPerBlock(ctx context.Context) uint64 { return 42 }
+func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int { return big.NewInt(42) }
 
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }
 func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }


### PR DESCRIPTION
This solution doesn't work for us, because we cannot be sure that the arbitrum nodes will be talking to L1s that are running our fork of go-ethereum.