### PR TITLE
Make it illegal to call Commit with noStorageWiping=true on arbitrum

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1234,6 +1234,10 @@ func (s *StateDB) GetTrie() Trie {
 // commit gathers the state mutations accumulated along with the associated
 // trie changes, resetting all internal flags with the new state as the base.
 func (s *StateDB) commit(deleteEmptyObjects bool, noStorageWiping bool) (*stateUpdate, error) {
+	// Arbitrum: Arbitrum chains don't support noStorageWiping == true
+	if noStorageWiping {
+		return nil, ErrArbStorageWipingRequired
+	}
 	if s.arbExtraData.arbTxFilter {
 		return nil, ErrArbTxFilter
 	}

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -180,6 +180,8 @@ func (s *StateDB) Recording() bool {
 
 var ErrArbTxFilter error = errors.New("internal error")
 
+var ErrArbStorageWipingRequired error = errors.New("arbitrum chains require storage wiping")
+
 type ArbitrumExtraData struct {
 	unexpectedBalanceDelta *big.Int                      // total balance change across all accounts
 	userWasms              UserWasms                     // user wasms encountered during execution


### PR DESCRIPTION
This is in response to a suggestion on a code review. Essentially, we always want to wipe storage for Arbitrum chains during stateDB commits.