### PR TITLE
Adds a hook to the TxProcessor for EIP-7623

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -493,7 +493,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gasRemaining, gas)
 	}
 	// Gas limit suffices for the floor data cost (EIP-7623)
-	if rules.IsPrague {
+	if rules.IsPrague && st.evm.ProcessingHook.IsCalldataPricingIncreaseEnabled() {
 		floorDataGas, err = FloorDataGas(msg.Data)
 		if err != nil {
 			return nil, err
@@ -576,7 +576,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	// Compute refund counter, capped to a refund quotient.
 	gasRefund := st.calcRefund()
 	st.gasRemaining += gasRefund
-	if rules.IsPrague {
+	if rules.IsPrague && st.evm.ProcessingHook.IsCalldataPricingIncreaseEnabled() {
 		// After EIP-7623: Data-heavy transactions pay the floor gas.
 		if st.gasUsed() < floorDataGas {
 			prev := st.gasRemaining

--- a/core/vm/evm_arbitrum.go
+++ b/core/vm/evm_arbitrum.go
@@ -53,6 +53,7 @@ type TxProcessingHook interface {
 	FillReceiptInfo(receipt *types.Receipt)
 	MsgIsNonMutating() bool
 	ExecuteWASM(scope *ScopeContext, input []byte, interpreter *EVMInterpreter) ([]byte, error)
+	IsCalldataPricingIncreaseEnabled() bool
 }
 
 type DefaultTxProcessor struct {
@@ -104,4 +105,9 @@ func (p DefaultTxProcessor) MsgIsNonMutating() bool {
 func (p DefaultTxProcessor) ExecuteWASM(scope *ScopeContext, input []byte, interpreter *EVMInterpreter) ([]byte, error) {
 	log.Crit("tried to execute WASM with default processing hook")
 	return nil, nil
+}
+
+// The default behavior for go-ethereum is to enable calldata pricing increase. (EIP-7623)
+func (p DefaultTxProcessor) IsCalldataPricingIncreaseEnabled() bool {
+	return true
 }


### PR DESCRIPTION
This will allow the Arbitrum implementation of the hook to selectively enable it only when the ArbOwner calls a specific contract.

Part of: NIT-3139