### PR TITLE
Support arbos40

### DIFF
--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -42,8 +42,8 @@ const ArbosVersion_FixRedeemGas = ArbosVersion_11
 const ArbosVersion_Stylus = ArbosVersion_30
 const ArbosVersion_StylusFixes = ArbosVersion_31
 const ArbosVersion_StylusChargingFixes = ArbosVersion_32
-const MaxArbosVersionSupported = ArbosVersion_32
-const MaxDebugArbosVersionSupported = ArbosVersion_32
+const MaxArbosVersionSupported = ArbosVersion_40
+const MaxDebugArbosVersionSupported = ArbosVersion_40
 
 type ArbitrumChainParams struct {
 	EnableArbOS               bool


### PR DESCRIPTION
This allows the devtest environment to be set to arbos40.