### PR TITLE
Add BalanceChangeReason for refund of retryable's excess submission fee

### DIFF
--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -303,6 +303,7 @@ const (
 	BalanceChangeEscrowTransfer
 	BalanceChangeTransferBatchposterReward
 	BalanceChangeTransferBatchposterRefund
+	BalanceChangeTransferRetryableExcessRefund
 	// Stylus
 	BalanceChangeTransferActivationFee
 	BalanceChangeTransferActivationReimburse
@@ -335,7 +336,7 @@ func (b BalanceChangeReason) Str() string {
 		return "undoRefund"
 	case BalanceChangeEscrowTransfer:
 		return "escrow"
-	case BalanceChangeTransferInfraRefund, BalanceChangeTransferNetworkRefund:
+	case BalanceChangeTransferInfraRefund, BalanceChangeTransferNetworkRefund, BalanceChangeTransferRetryableExcessRefund:
 		return "refund"
 	// Batchposter
 	case BalanceChangeTransferBatchposterReward:


### PR DESCRIPTION
This PR adds a new balance change reason `BalanceChangeTransferRetryableExcessRefund` that represents the refund transfers done to `ArbitrumSubmitRetryableTx`'s `FeeRefundAddr`.

Part of NIT-3174