### PR TITLE
Add detection of Arbos Version to the evaluation of IsPrauge

### DIFF
--- a/arbitrum/conditionaltx.go
+++ b/arbitrum/conditionaltx.go
@@ -45,7 +45,7 @@ func SubmitConditionalTransaction(ctx context.Context, b *APIBackend, tx *types.
 	}
 	// Print a log with full tx details for manual investigations and interventions
 	arbosVersion := types.DeserializeHeaderExtraInformation(b.CurrentBlock()).ArbOSFormatVersion
-	signer := types.VersionedArbitrumSigner(b.ChainConfig(), b.CurrentBlock().Number, b.CurrentBlock().Time, arbosVersion)
+	signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number, b.CurrentBlock().Time, arbosVersion)
 	from, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err

--- a/arbitrum/conditionaltx.go
+++ b/arbitrum/conditionaltx.go
@@ -44,7 +44,8 @@ func SubmitConditionalTransaction(ctx context.Context, b *APIBackend, tx *types.
 		return common.Hash{}, err
 	}
 	// Print a log with full tx details for manual investigations and interventions
-	signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number, b.CurrentBlock().Time)
+	arbosVersion := types.DeserializeHeaderExtraInformation(b.CurrentBlock()).ArbOSFormatVersion
+	signer := types.VersionedArbitrumSigner(b.ChainConfig(), b.CurrentBlock().Number, b.CurrentBlock().Time, arbosVersion)
 	from, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -355,7 +355,8 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 
 	// Gather the execution-layer triggered requests.
 	var requests [][]byte
-	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time, vmContext.ArbOSVersion) {
+	// Arbitrum doesn't support Deposit/Withdrawal/Consolidation requests.
+	if !chainConfig.IsArbitrum() && chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time, vmContext.ArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110
 		var allLogs []*types.Log

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -216,7 +216,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
+	if pre.Env.BlockHashes != nil && chainConfig.IsPrague(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp, vmContext.ArbOSVersion) {
 		var (
 			prevNumber = pre.Env.Number - 1
 			prevHash   = pre.Env.BlockHashes[math.HexOrDecimal64(prevNumber)]
@@ -355,7 +355,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 
 	// Gather the execution-layer triggered requests.
 	var requests [][]byte
-	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time) {
+	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time, vmContext.ArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110
 		var allLogs []*types.Log

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -147,7 +147,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 	}
 	var (
 		statedb     = MakePreState(rawdb.NewMemoryDatabase(), pre.Pre)
-		signer      = types.MakeSigner(chainConfig, new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp)
+		signer      = types.MakeSigner(chainConfig, new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp, params.MaxArbosVersionSupported)
 		gaspool     = new(core.GasPool)
 		blockHash   = common.Hash{0x13, 0x37}
 		rejectedTxs []*rejectedTx

--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -105,7 +105,7 @@ func Transaction(ctx *cli.Context) error {
 			return NewError(ErrorIO, errors.New("only rlp supported"))
 		}
 	}
-	signer := types.MakeSigner(chainConfig, new(big.Int), 0)
+	signer := types.MakeSigner(chainConfig, new(big.Int), 0, params.MaxArbosVersionSupported)
 
 	// We now have the transactions in 'body', which is supposed to be an
 	// rlp list of transactions

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -107,7 +107,8 @@ func MaxBlobsPerBlock(cfg *params.ChainConfig, time uint64) int {
 	switch {
 	case cfg.IsOsaka(london, time) && s.Osaka != nil:
 		return s.Osaka.Max
-	case cfg.IsPrague(london, time) && s.Prague != nil:
+	// we can use 0 here because arbitrum doesn't support Blob transactions.
+	case cfg.IsPrague(london, time, 0) && s.Prague != nil:
 		return s.Prague.Max
 	// we can use 0 here because arbitrum doesn't support Blob transactions.
 	case cfg.IsCancun(london, time, 0) && s.Cancun != nil:
@@ -153,7 +154,8 @@ func targetBlobsPerBlock(cfg *params.ChainConfig, time uint64) int {
 	switch {
 	case cfg.IsOsaka(london, time) && s.Osaka != nil:
 		return s.Osaka.Target
-	case cfg.IsPrague(london, time) && s.Prague != nil:
+	// we can use 0 here because arbitrum doesn't support Blob transactions.
+	case cfg.IsPrague(london, time, 0) && s.Prague != nil:
 		return s.Prague.Target
 	// we can use 0 here because arbitrum doesn't support Blob transactions.
 	case cfg.IsCancun(london, time, 0) && s.Cancun != nil:

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1744,7 +1744,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 	}
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
 	arbosVersion := types.DeserializeHeaderExtraInformation(chain[0].Header()).ArbOSFormatVersion
-	SenderCacher().RecoverFromBlocks(types.VersionedArbitrumSigner(bc.chainConfig, chain[0].Number(), chain[0].Time(), arbosVersion), chain)
+	SenderCacher().RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time(), arbosVersion), chain)
 
 	var (
 		stats     = insertStats{startTime: mclock.Now()}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1743,7 +1743,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 		return nil, 0, nil
 	}
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
-	SenderCacher().RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
+	arbosVersion := types.DeserializeHeaderExtraInformation(chain[0].Header()).ArbOSFormatVersion
+	SenderCacher().RecoverFromBlocks(types.VersionedArbitrumSigner(bc.chainConfig, chain[0].Number(), chain[0].Time(), arbosVersion), chain)
 
 	var (
 		stats     = insertStats{startTime: mclock.Now()}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -201,7 +201,8 @@ func (b *BlockGen) Gas() uint64 {
 
 // Signer returns a valid signer instance for the current block.
 func (b *BlockGen) Signer() types.Signer {
-	return types.MakeSigner(b.cm.config, b.header.Number, b.header.Time)
+	arbosVersion := types.DeserializeHeaderExtraInformation(b.header).ArbOSFormatVersion
+	return types.VersionedArbitrumSigner(b.cm.config, b.header.Number, b.header.Time, arbosVersion)
 }
 
 // AddUncheckedReceipt forcefully adds a receipts to the block without a

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -315,9 +315,9 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 		statedb = statedb.Copy()
 	}
 
-	blockContext := NewEVMBlockContext(b.header, b.cm, &b.header.Coinbase)
+	arbosVersion := types.DeserializeHeaderExtraInformation(b.header).ArbOSFormatVersion
 	// Arbitrum doesn't support Deposit, Withdrawal, or Consolidation requests.
-	if !b.cm.config.IsArbitrum() && b.cm.config.IsPrague(b.header.Number, b.header.Time, blockContext.ArbOSVersion) {
+	if !b.cm.config.IsArbitrum() && b.cm.config.IsPrague(b.header.Number, b.header.Time, arbosVersion) {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		var blockLogs []*types.Log

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -316,7 +316,8 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 	}
 
 	blockContext := NewEVMBlockContext(b.header, b.cm, &b.header.Coinbase)
-	if b.cm.config.IsPrague(b.header.Number, b.header.Time, blockContext.ArbOSVersion) {
+	// Arbitrum doesn't support Deposit, Withdrawal, or Consolidation requests.
+	if !b.cm.config.IsArbitrum() && b.cm.config.IsPrague(b.header.Number, b.header.Time, blockContext.ArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		var blockLogs []*types.Log

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -314,7 +314,8 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 		statedb = statedb.Copy()
 	}
 
-	if b.cm.config.IsPrague(b.header.Number, b.header.Time) {
+	blockContext := NewEVMBlockContext(b.header, b.cm, &b.header.Coinbase)
+	if b.cm.config.IsPrague(b.header.Number, b.header.Time, blockContext.ArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		var blockLogs []*types.Log
@@ -386,9 +387,9 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyDAOHardFork(statedb)
 		}
 
-		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
+		blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)
+		if config.IsPrague(b.header.Number, b.header.Time, blockContext.ArbOSVersion) || config.IsVerkle(b.header.Number, b.header.Time) {
 			// EIP-2935
-			blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)
 			blockContext.Random = &common.Hash{} // enable post-merge instruction set
 			evm := vm.NewEVM(blockContext, statedb, cm.config, vm.Config{})
 			ProcessParentBlockHash(b.header.ParentHash, evm)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -202,7 +202,7 @@ func (b *BlockGen) Gas() uint64 {
 // Signer returns a valid signer instance for the current block.
 func (b *BlockGen) Signer() types.Signer {
 	arbosVersion := types.DeserializeHeaderExtraInformation(b.header).ArbOSFormatVersion
-	return types.VersionedArbitrumSigner(b.cm.config, b.header.Number, b.header.Time, arbosVersion)
+	return types.MakeSigner(b.cm.config, b.header.Number, b.header.Time, arbosVersion)
 }
 
 // AddUncheckedReceipt forcefully adds a receipts to the block without a

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -508,7 +508,7 @@ func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
 				head.BlobGasUsed = new(uint64)
 			}
 		}
-		if conf.IsPrague(num, g.Timestamp) {
+		if conf.IsPrague(num, g.Timestamp, arbosVersion) {
 			head.RequestsHash = &types.EmptyRequestsHash
 		}
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -50,7 +50,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		gaspool      = new(GasPool).AddGas(block.GasLimit())
 		blockContext = NewEVMBlockContext(header, p.chain, nil)
 		evm          = vm.NewEVM(blockContext, statedb, p.config, cfg)
-		signer       = types.MakeSigner(p.config, header.Number, header.Time)
+		signer       = types.VersionedArbitrumSigner(p.config, header.Number, header.Time, blockContext.ArbOSVersion)
 	)
 	// Iterate over and process the individual transactions
 	byzantium := p.config.IsByzantium(block.Number())

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -50,7 +50,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		gaspool      = new(GasPool).AddGas(block.GasLimit())
 		blockContext = NewEVMBlockContext(header, p.chain, nil)
 		evm          = vm.NewEVM(blockContext, statedb, p.config, cfg)
-		signer       = types.VersionedArbitrumSigner(p.config, header.Number, header.Time, blockContext.ArbOSVersion)
+		signer       = types.MakeSigner(p.config, header.Number, header.Time, blockContext.ArbOSVersion)
 	)
 	// Iterate over and process the individual transactions
 	byzantium := p.config.IsByzantium(block.Number())

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -84,7 +84,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if p.config.IsPrague(block.Number(), block.Time()) || p.config.IsVerkle(block.Number(), block.Time()) {
+	if p.config.IsPrague(block.Number(), block.Time(), context.ArbOSVersion) || p.config.IsVerkle(block.Number(), block.Time()) {
 		ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 
@@ -106,7 +106,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	// Read requests if Prague is enabled.
 	var requests [][]byte
-	if p.config.IsPrague(block.Number(), block.Time()) {
+	if p.config.IsPrague(block.Number(), block.Time(), context.ArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110
 		if err := ParseDepositLogs(&requests, allLogs, p.config); err != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -70,7 +70,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	var (
 		context vm.BlockContext
-		signer  = types.MakeSigner(p.config, header.Number, header.Time)
 	)
 
 	// Apply pre-execution system calls.
@@ -80,6 +79,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	context = NewEVMBlockContext(header, p.chain, nil)
 	evm := vm.NewEVM(context, tracingStateDB, p.config, cfg)
+
+	signer := types.VersionedArbitrumSigner(p.config, header.Number, header.Time, context.ArbOSVersion)
 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
@@ -213,7 +214,7 @@ func ApplyTransaction(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *
 }
 
 func ApplyTransactionWithResultFilter(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, runMode MessageRunMode, resultFilter func(*ExecutionResult) error) (*types.Receipt, *ExecutionResult, error) {
-	msg, err := TransactionToMessage(tx, types.MakeSigner(evm.ChainConfig(), header.Number, header.Time), header.BaseFee, runMode)
+	msg, err := TransactionToMessage(tx, types.VersionedArbitrumSigner(evm.ChainConfig(), header.Number, header.Time, evm.Context.ArbOSVersion), header.BaseFee, runMode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -80,7 +80,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	context = NewEVMBlockContext(header, p.chain, nil)
 	evm := vm.NewEVM(context, tracingStateDB, p.config, cfg)
 
-	signer := types.VersionedArbitrumSigner(p.config, header.Number, header.Time, context.ArbOSVersion)
+	signer := types.MakeSigner(p.config, header.Number, header.Time, context.ArbOSVersion)
 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
@@ -214,7 +214,7 @@ func ApplyTransaction(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *
 }
 
 func ApplyTransactionWithResultFilter(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, runMode MessageRunMode, resultFilter func(*ExecutionResult) error) (*types.Receipt, *ExecutionResult, error) {
-	msg, err := TransactionToMessage(tx, types.VersionedArbitrumSigner(evm.ChainConfig(), header.Number, header.Time, evm.Context.ArbOSVersion), header.BaseFee, runMode)
+	msg, err := TransactionToMessage(tx, types.MakeSigner(evm.ChainConfig(), header.Number, header.Time, evm.Context.ArbOSVersion), header.BaseFee, runMode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -107,7 +107,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	// Read requests if Prague is enabled.
 	var requests [][]byte
-	if p.config.IsPrague(block.Number(), block.Time(), context.ArbOSVersion) {
+	// Arbitrum has no Deposit, Witdrawal, or Consolidation requests.
+	if !p.config.IsArbitrum() && p.config.IsPrague(block.Number(), block.Time(), context.ArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110
 		if err := ParseDepositLogs(&requests, allLogs, p.config); err != nil {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -121,7 +121,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return fmt.Errorf("%w: gas %v, minimum needed %v", core.ErrIntrinsicGas, tx.Gas(), intrGas)
 	}
 	// Ensure the transaction can cover floor data gas.
-	if opts.Config.IsPrague(head.Number, head.Time) {
+	if opts.Config.IsPrague(head.Number, head.Time, arbosVersion) {
 		floorDataGas, err := core.FloorDataGas(tx.Data())
 		if err != nil {
 			return err

--- a/core/types/arbitrum_signer.go
+++ b/core/types/arbitrum_signer.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 var ArbosAddress = common.HexToAddress("0xa4b05")
@@ -95,31 +94,4 @@ func (s arbitrumSigner) Hash(tx *Transaction) common.Hash {
 		return s.Signer.Hash(fakeTx)
 	}
 	return s.Signer.Hash(tx)
-}
-
-// VersionedArbitrumSigner wraps the go-ethereum signer in an ArbitrumSigner
-// that can handle both legacy and new transactions.
-func VersionedArbitrumSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64, arbitrumVersion uint64) Signer {
-	var signer Signer
-	switch {
-	case config.IsPrague(blockNumber, blockTime, arbitrumVersion):
-		signer = NewPragueSigner(config.ChainID)
-	// we can use 0 here because arbitrum doesn't support Blob transactions.
-	case config.IsCancun(blockNumber, blockTime, 0):
-		signer = NewCancunSigner(config.ChainID)
-	case config.IsLondon(blockNumber):
-		signer = NewLondonSigner(config.ChainID)
-	case config.IsBerlin(blockNumber):
-		signer = NewEIP2930Signer(config.ChainID)
-	case config.IsEIP155(blockNumber):
-		signer = NewEIP155Signer(config.ChainID)
-	case config.IsHomestead(blockNumber):
-		signer = HomesteadSigner{}
-	default:
-		signer = FrontierSigner{}
-	}
-	if config.IsArbitrum() {
-		signer = NewArbitrumSigner(signer)
-	}
-	return signer
 }

--- a/core/types/arbitrum_signer.go
+++ b/core/types/arbitrum_signer.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var ArbosAddress = common.HexToAddress("0xa4b05")
@@ -94,4 +95,31 @@ func (s arbitrumSigner) Hash(tx *Transaction) common.Hash {
 		return s.Signer.Hash(fakeTx)
 	}
 	return s.Signer.Hash(tx)
+}
+
+// VersionedArbitrumSigner wraps the go-ethereum signer in an ArbitrumSigner
+// that can handle both legacy and new transactions.
+func VersionedArbitrumSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64, arbitrumVersion uint64) Signer {
+	var signer Signer
+	switch {
+	case config.IsPrague(blockNumber, blockTime, arbitrumVersion):
+		signer = NewPragueSigner(config.ChainID)
+	// we can use 0 here because arbitrum doesn't support Blob transactions.
+	case config.IsCancun(blockNumber, blockTime, 0):
+		signer = NewCancunSigner(config.ChainID)
+	case config.IsLondon(blockNumber):
+		signer = NewLondonSigner(config.ChainID)
+	case config.IsBerlin(blockNumber):
+		signer = NewEIP2930Signer(config.ChainID)
+	case config.IsEIP155(blockNumber):
+		signer = NewEIP155Signer(config.ChainID)
+	case config.IsHomestead(blockNumber):
+		signer = HomesteadSigner{}
+	default:
+		signer = FrontierSigner{}
+	}
+	if config.IsArbitrum() {
+		signer = NewArbitrumSigner(signer)
+	}
+	return signer
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -400,7 +400,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 // DeriveFields fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
 func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, time uint64, baseFee *big.Int, blobGasPrice *big.Int, txs []*Transaction) error {
-	signer := MakeSigner(config, new(big.Int).SetUint64(number), time)
+	signer := MakeSigner(config, new(big.Int).SetUint64(number), time, params.MaxArbosVersionSupported)
 
 	logIndex := uint(0)
 	if len(txs) != len(rs) {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -37,6 +37,11 @@ type sigCache struct {
 }
 
 // MakeSigner returns a Signer based on the given chain config and block number.
+//
+// Arbitrum: If the signer is being used in any state-transition affecting code,
+// then this is not the right function to use. Instead, use
+// types.VersionedArbitrumSigner(), which will return the correct signer based
+// on the current block number and time, and active arbitrum version.
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -39,17 +39,13 @@ type sigCache struct {
 // MakeSigner returns a Signer based on the given chain config and block number.
 //
 // Arbitrum: If the signer is being used in any state-transition affecting code,
-// then this is not the right function to use. Instead, use
-// types.VersionedArbitrumSigner(), which will return the correct signer based
-// on the current block number and time, and active arbitrum version.
-func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
+// then the active arbos version must be passed in. In places which don't affect
+// the state transition function, it is okay to pass in
+// params.MaxArbosVersionSupported.
+func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64, arbosVersion uint64) Signer {
 	var signer Signer
 	switch {
-	// Using MaxArbosVersionSupported effectively means that if Arbos is
-	// enabled, and we're running the current version of the OCL fork of
-	// go-ethereum, or the machine with the current wasm root, then, we will use
-	// the Prague signer.
-	case config.IsPrague(blockNumber, blockTime, params.MaxArbosVersionSupported):
+	case config.IsPrague(blockNumber, blockTime, arbosVersion):
 		signer = NewPragueSigner(config.ChainID)
 	// we can use 0 here because arbitrum doesn't support Blob transactions.
 	case config.IsCancun(blockNumber, blockTime, 0):

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,11 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsPrague(blockNumber, blockTime):
+	// Using MaxArbosVersionSupported effectively means that if Arbos is
+	// enalbed, and we're running the current version of the OCL fork of
+	// go-ethereum, or the machine with the current wasm root, then, we will use
+	// the Prague signer.
+	case config.IsPrague(blockNumber, blockTime, params.MaxArbosVersionSupported):
 		signer = NewPragueSigner(config.ChainID)
 	// we can use 0 here because arbitrum doesn't support Blob transactions.
 	case config.IsCancun(blockNumber, blockTime, 0):

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -41,7 +41,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 	var signer Signer
 	switch {
 	// Using MaxArbosVersionSupported effectively means that if Arbos is
-	// enalbed, and we're running the current version of the OCL fork of
+	// enabled, and we're running the current version of the OCL fork of
 	// go-ethereum, or the machine with the current wasm root, then, we will use
 	// the Prague signer.
 	case config.IsPrague(blockNumber, blockTime, params.MaxArbosVersionSupported):

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -44,7 +44,7 @@ func makeChain(n int, seed byte, parent *types.Block, empty bool) ([]*types.Bloc
 		block.SetCoinbase(common.Address{seed})
 		// Add one tx to every secondblock
 		if !empty && i%2 == 0 {
-			signer := types.MakeSigner(params.TestChainConfig, block.Number(), block.Timestamp())
+			signer := types.MakeSigner(params.TestChainConfig, block.Number(), block.Timestamp(), params.MaxArbosVersionSupported)
 			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, block.BaseFee(), nil), signer, testKey)
 			if err != nil {
 				panic(err)

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -168,7 +168,7 @@ func (tc *testChain) generate(n int, seed byte, parent *types.Block, heavy bool)
 		}
 		// Include transactions to the miner to make blocks more interesting.
 		if parent == tc.blocks[0] && i%22 == 0 {
-			signer := types.MakeSigner(params.TestChainConfig, block.Number(), block.Timestamp())
+			signer := types.MakeSigner(params.TestChainConfig, block.Number(), block.Timestamp(), params.MaxArbosVersionSupported)
 			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, block.BaseFee(), nil), signer, testKey)
 			if err != nil {
 				panic(err)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -251,7 +251,7 @@ func (oracle *Oracle) getBlockValues(ctx context.Context, blockNum uint64, limit
 		return
 	}
 	arbosVersion := types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
-	signer := types.VersionedArbitrumSigner(oracle.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
+	signer := types.MakeSigner(oracle.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
 
 	// Sort the transaction by effective tip in ascending sort.
 	txs := block.Transactions()

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -250,7 +250,8 @@ func (oracle *Oracle) getBlockValues(ctx context.Context, blockNum uint64, limit
 		}
 		return
 	}
-	signer := types.MakeSigner(oracle.backend.ChainConfig(), block.Number(), block.Time())
+	arbosVersion := types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
+	signer := types.VersionedArbitrumSigner(oracle.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
 
 	// Sort the transaction by effective tip in ascending sort.
 	txs := block.Transactions()

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -261,7 +261,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
 	// If prague hardfork, insert parent block hash in the state as per EIP-2935.
-	if eth.blockchain.Config().IsPrague(block.Number(), block.Time()) {
+	if eth.blockchain.Config().IsPrague(block.Number(), block.Time(), context.ArbOSVersion) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	if txIndex == 0 && len(block.Transactions()) == 0 {

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -268,7 +268,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		return nil, vm.BlockContext{}, statedb, release, nil
 	}
 	// Recompute transactions up to the target index.
-	signer := types.MakeSigner(eth.blockchain.Config(), block.Number(), block.Time())
+	signer := types.VersionedArbitrumSigner(eth.blockchain.Config(), block.Number(), block.Time(), evm.Context.ArbOSVersion)
 	for idx, tx := range block.Transactions() {
 		if idx == txIndex {
 			return tx, context, statedb, release, nil

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -268,7 +268,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		return nil, vm.BlockContext{}, statedb, release, nil
 	}
 	// Recompute transactions up to the target index.
-	signer := types.VersionedArbitrumSigner(eth.blockchain.Config(), block.Number(), block.Time(), evm.Context.ArbOSVersion)
+	signer := types.MakeSigner(eth.blockchain.Config(), block.Number(), block.Time(), evm.Context.ArbOSVersion)
 	for idx, tx := range block.Transactions() {
 		if idx == txIndex {
 			return tx, context, statedb, release, nil

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -389,7 +389,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 			}
 			// Insert parent hash in history contract.
-			if api.backend.ChainConfig().IsPrague(next.Number(), next.Time()) {
+			if api.backend.ChainConfig().IsPrague(next.Number(), next.Time(), context.ArbOSVersion) {
 				core.ProcessParentBlockHash(next.ParentHash(), evm)
 			}
 			// Clean out any pending release functions of trace state. Note this
@@ -544,7 +544,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if chainConfig.IsPrague(block.Number(), block.Time()) {
+	if chainConfig.IsPrague(block.Number(), block.Time(), vmctx.ArbOSVersion) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	for i, tx := range block.Transactions() {
@@ -608,7 +608,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time()) {
+	if api.backend.ChainConfig().IsPrague(block.Number(), block.Time(), blockCtx.ArbOSVersion) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 
@@ -785,7 +785,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}
-	if chainConfig.IsPrague(block.Number(), block.Time()) {
+	if chainConfig.IsPrague(block.Number(), block.Time(), vmctx.ArbOSVersion) {
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	for i, tx := range block.Transactions() {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -272,7 +272,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			for task := range taskCh {
 				var (
 					blockCtx = core.NewEVMBlockContext(task.block.Header(), api.chainContext(ctx), nil)
-					signer   = types.VersionedArbitrumSigner(api.backend.ChainConfig(), task.block.Number(), task.block.Time(), blockCtx.ArbOSVersion)
+					signer   = types.MakeSigner(api.backend.ChainConfig(), task.block.Number(), task.block.Time(), blockCtx.ArbOSVersion)
 				)
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
@@ -536,7 +536,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	var (
 		roots              []common.Hash
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-		signer             = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion)
+		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion)
 		chainConfig        = api.backend.ChainConfig()
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
 	)
@@ -625,7 +625,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		txs          = block.Transactions()
 		blockHash    = block.Hash()
 		arbosVersion = types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
-		signer       = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
+		signer       = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
 		results      = make([]*txTraceResult, len(txs))
 	)
 	for i, tx := range txs {
@@ -655,7 +655,7 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 		txs          = block.Transactions()
 		blockHash    = block.Hash()
 		arbosVersion = types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
-		signer       = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
+		signer       = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
 		results      = make([]*txTraceResult, len(txs))
 		pend         sync.WaitGroup
 	)
@@ -770,7 +770,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	var (
 		dumps       []string
 		vmctx       = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-		signer      = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion)
+		signer      = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion)
 		chainConfig = api.backend.ChainConfig()
 		canon       = true
 	)
@@ -889,7 +889,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 	defer release()
-	msg, err := core.TransactionToMessage(tx, types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion), block.BaseFee(), core.MessageReplayMode)
+	msg, err := core.TransactionToMessage(tx, types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion), block.BaseFee(), core.MessageReplayMode)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -271,8 +271,8 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			// Fetch and execute the block trace taskCh
 			for task := range taskCh {
 				var (
-					signer   = types.MakeSigner(api.backend.ChainConfig(), task.block.Number(), task.block.Time())
 					blockCtx = core.NewEVMBlockContext(task.block.Header(), api.chainContext(ctx), nil)
+					signer   = types.VersionedArbitrumSigner(api.backend.ChainConfig(), task.block.Number(), task.block.Time(), blockCtx.ArbOSVersion)
 				)
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
@@ -535,9 +535,9 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	defer release()
 	var (
 		roots              []common.Hash
-		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
-		chainConfig        = api.backend.ChainConfig()
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+		signer             = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion)
+		chainConfig        = api.backend.ChainConfig()
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
 	)
 	evm := vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
@@ -622,10 +622,11 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	}
 	// Native tracers have low overhead
 	var (
-		txs       = block.Transactions()
-		blockHash = block.Hash()
-		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
-		results   = make([]*txTraceResult, len(txs))
+		txs          = block.Transactions()
+		blockHash    = block.Hash()
+		arbosVersion = types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
+		signer       = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
+		results      = make([]*txTraceResult, len(txs))
 	)
 	for i, tx := range txs {
 		// Generate the next state snapshot fast without tracing
@@ -651,11 +652,12 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, statedb *state.StateDB, config *TraceConfig) ([]*txTraceResult, error) {
 	// Execute all the transaction contained within the block concurrently
 	var (
-		txs       = block.Transactions()
-		blockHash = block.Hash()
-		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
-		results   = make([]*txTraceResult, len(txs))
-		pend      sync.WaitGroup
+		txs          = block.Transactions()
+		blockHash    = block.Hash()
+		arbosVersion = types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
+		signer       = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), arbosVersion)
+		results      = make([]*txTraceResult, len(txs))
+		pend         sync.WaitGroup
 	)
 	threads := runtime.NumCPU()
 	if threads > len(txs) {
@@ -767,9 +769,9 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	// Execute transaction, either tracing all or just the requested one
 	var (
 		dumps       []string
-		signer      = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
-		chainConfig = api.backend.ChainConfig()
 		vmctx       = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+		signer      = types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion)
+		chainConfig = api.backend.ChainConfig()
 		canon       = true
 	)
 	// Check if there are any overrides: the caller may wish to enable a future
@@ -887,7 +889,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 	defer release()
-	msg, err := core.TransactionToMessage(tx, types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time()), block.BaseFee(), core.MessageReplayMode)
+	msg, err := core.TransactionToMessage(tx, types.VersionedArbitrumSigner(api.backend.ChainConfig(), block.Number(), block.Time(), vmctx.ArbOSVersion), block.BaseFee(), core.MessageReplayMode)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -176,8 +176,8 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 		return nil, vm.BlockContext{}, statedb, release, nil
 	}
 	// Recompute transactions up to the target index.
-	signer := types.MakeSigner(b.chainConfig, block.Number(), block.Time())
 	context := core.NewEVMBlockContext(block.Header(), b.chain, nil)
+	signer := types.VersionedArbitrumSigner(b.chainConfig, block.Number(), block.Time(), context.ArbOSVersion)
 	evm := vm.NewEVM(context, statedb, b.chainConfig, vm.Config{})
 	for idx, tx := range block.Transactions() {
 		if idx == txIndex {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -177,7 +177,7 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	}
 	// Recompute transactions up to the target index.
 	context := core.NewEVMBlockContext(block.Header(), b.chain, nil)
-	signer := types.VersionedArbitrumSigner(b.chainConfig, block.Number(), block.Time(), context.ArbOSVersion)
+	signer := types.MakeSigner(b.chainConfig, block.Number(), block.Time(), context.ArbOSVersion)
 	evm := vm.NewEVM(context, statedb, b.chainConfig, vm.Config{})
 	for idx, tx := range block.Transactions() {
 		if idx == txIndex {

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -122,8 +122,8 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			}
 			// Configure a blockchain with the given prestate
 			var (
-				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
 				context = test.Context.toBlockContext(test.Genesis)
+				signer  = types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 				st      = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
 			)
 			st.Close()
@@ -212,8 +212,8 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 	if err := tx.UnmarshalBinary(common.FromHex(test.Input)); err != nil {
 		b.Fatalf("failed to parse testcase input: %v", err)
 	}
-	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
 	context := test.Context.toBlockContext(test.Genesis)
+	signer := types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, core.MessageReplayMode)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -123,7 +123,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			// Configure a blockchain with the given prestate
 			var (
 				context = test.Context.toBlockContext(test.Genesis)
-				signer  = types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
+				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 				st      = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
 			)
 			st.Close()
@@ -213,7 +213,7 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		b.Fatalf("failed to parse testcase input: %v", err)
 	}
 	context := test.Context.toBlockContext(test.Genesis)
-	signer := types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
+	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, core.MessageReplayMode)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -96,8 +96,8 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	if err := rlp.DecodeBytes(common.FromHex(test.Input), tx); err != nil {
 		return fmt.Errorf("failed to parse testcase input: %v", err)
 	}
-	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
 	context := test.Context.toBlockContext(test.Genesis)
+	signer := types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
 	defer state.Close()
 

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -97,7 +97,7 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 		return fmt.Errorf("failed to parse testcase input: %v", err)
 	}
 	context := test.Context.toBlockContext(test.Genesis)
-	signer := types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
+	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
 	defer state.Close()
 

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -89,7 +89,7 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			// Configure a blockchain with the given prestate
 			var (
 				context = test.Context.toBlockContext(test.Genesis)
-				signer  = types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
+				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 				state   = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
 			)
 			defer state.Close()

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -88,8 +88,8 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			}
 			// Configure a blockchain with the given prestate
 			var (
-				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
 				context = test.Context.toBlockContext(test.Genesis)
+				signer  = types.VersionedArbitrumSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time), context.ArbOSVersion)
 				state   = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
 			)
 			defer state.Close()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -626,7 +626,8 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 	}
 
 	// Derive the sender.
-	signer := types.MakeSigner(api.b.ChainConfig(), block.Number(), block.Time())
+	arbosVersion := types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
+	signer := types.VersionedArbitrumSigner(api.b.ChainConfig(), block.Number(), block.Time(), arbosVersion)
 
 	result := make([]map[string]interface{}, len(receipts))
 	for i, receipt := range receipts {
@@ -1164,8 +1165,8 @@ type RPCTransaction struct {
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, blockTime uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
-	signer := types.MakeSigner(config, new(big.Int).SetUint64(blockNumber), blockTime)
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, blockTime uint64, index uint64, baseFee *big.Int, config *params.ChainConfig, arbosVersion uint64) *RPCTransaction {
+	signer := types.VersionedArbitrumSigner(config, new(big.Int).SetUint64(blockNumber), blockTime, arbosVersion)
 	from, _ := types.Sender(signer, tx)
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
@@ -1312,7 +1313,8 @@ func NewRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 		blockNumber = current.Number.Uint64()
 		blockTime = current.Time
 	}
-	return newRPCTransaction(tx, common.Hash{}, blockNumber, blockTime, 0, baseFee, config)
+	arbosVersion := types.DeserializeHeaderExtraInformation(current).ArbOSFormatVersion
+	return newRPCTransaction(tx, common.Hash{}, blockNumber, blockTime, 0, baseFee, config, arbosVersion)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
@@ -1321,7 +1323,8 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *param
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time(), index, b.BaseFee(), config)
+	arbosVersion := types.DeserializeHeaderExtraInformation(b.Header()).ArbOSFormatVersion
+	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time(), index, b.BaseFee(), config, arbosVersion)
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.
@@ -1545,7 +1548,8 @@ func (api *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common
 	if err != nil {
 		return nil, err
 	}
-	return newRPCTransaction(tx, blockHash, blockNumber, header.Time, index, header.BaseFee, api.b.ChainConfig()), nil
+	arbosVersion := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
+	return newRPCTransaction(tx, blockHash, blockNumber, header.Time, index, header.BaseFee, api.b.ChainConfig(), arbosVersion), nil
 }
 
 // GetRawTransactionByHash returns the bytes of the transaction for the given hash.
@@ -1587,7 +1591,8 @@ func (api *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash commo
 	receipt := receipts[index]
 
 	// Derive the sender.
-	signer := types.MakeSigner(api.b.ChainConfig(), header.Number, header.Time)
+	arbosVersion := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
+	signer := types.VersionedArbitrumSigner(api.b.ChainConfig(), header.Number, header.Time, arbosVersion)
 	return marshalReceipt(ctx, receipt, blockHash, blockNumber, signer, tx, int(index), api.b)
 }
 
@@ -1696,7 +1701,8 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	}
 	// Print a log with full tx details for manual investigations and interventions
 	head := b.CurrentBlock()
-	signer := types.MakeSigner(b.ChainConfig(), head.Number, head.Time)
+	arbosVersion := types.DeserializeHeaderExtraInformation(head).ArbOSFormatVersion
+	signer := types.VersionedArbitrumSigner(b.ChainConfig(), head.Number, head.Time, arbosVersion)
 	from, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -627,7 +627,7 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 
 	// Derive the sender.
 	arbosVersion := types.DeserializeHeaderExtraInformation(block.Header()).ArbOSFormatVersion
-	signer := types.VersionedArbitrumSigner(api.b.ChainConfig(), block.Number(), block.Time(), arbosVersion)
+	signer := types.MakeSigner(api.b.ChainConfig(), block.Number(), block.Time(), arbosVersion)
 
 	result := make([]map[string]interface{}, len(receipts))
 	for i, receipt := range receipts {
@@ -1166,7 +1166,7 @@ type RPCTransaction struct {
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
 func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, blockTime uint64, index uint64, baseFee *big.Int, config *params.ChainConfig, arbosVersion uint64) *RPCTransaction {
-	signer := types.VersionedArbitrumSigner(config, new(big.Int).SetUint64(blockNumber), blockTime, arbosVersion)
+	signer := types.MakeSigner(config, new(big.Int).SetUint64(blockNumber), blockTime, arbosVersion)
 	from, _ := types.Sender(signer, tx)
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
@@ -1592,7 +1592,7 @@ func (api *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash commo
 
 	// Derive the sender.
 	arbosVersion := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
-	signer := types.VersionedArbitrumSigner(api.b.ChainConfig(), header.Number, header.Time, arbosVersion)
+	signer := types.MakeSigner(api.b.ChainConfig(), header.Number, header.Time, arbosVersion)
 	return marshalReceipt(ctx, receipt, blockHash, blockNumber, signer, tx, int(index), api.b)
 }
 
@@ -1702,7 +1702,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	// Print a log with full tx details for manual investigations and interventions
 	head := b.CurrentBlock()
 	arbosVersion := types.DeserializeHeaderExtraInformation(head).ArbOSFormatVersion
-	signer := types.VersionedArbitrumSigner(b.ChainConfig(), head.Number, head.Time, arbosVersion)
+	signer := types.MakeSigner(b.ChainConfig(), head.Number, head.Time, arbosVersion)
 	from, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -85,7 +85,7 @@ func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainCo
 		}
 
 		// rpcTransaction
-		rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config)
+		rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config, params.MaxArbosVersionSupported)
 		if data, err := json.Marshal(rpcTx); err != nil {
 			t.Fatalf("test %d: marshalling failed; %v", i, err)
 		} else if err = tx2.UnmarshalJSON(data); err != nil {

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -169,9 +169,10 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		}
 	}
 	arbOSVersion := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
+	parentArbOSVersion := types.DeserializeHeaderExtraInformation(parent).ArbOSFormatVersion
 	if sim.chainConfig.IsCancun(header.Number, header.Time, arbOSVersion) {
 		var excess uint64
-		if sim.chainConfig.IsCancun(parent.Number, parent.Time, arbOSVersion) {
+		if sim.chainConfig.IsCancun(parent.Number, parent.Time, parentArbOSVersion) {
 			excess = eip4844.CalcExcessBlobGas(sim.chainConfig, parent, header.Time)
 		}
 		header.ExcessBlobGas = &excess
@@ -270,11 +271,11 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	}
 	header.Root = sim.state.IntermediateRoot(true)
 	header.GasUsed = gasUsed
-	if sim.chainConfig.IsCancun(header.Number, header.Time, types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion) {
+	if sim.chainConfig.IsCancun(header.Number, header.Time, arbOSVersion) {
 		header.BlobGasUsed = &blobGasUsed
 	}
 	var withdrawals types.Withdrawals
-	if sim.chainConfig.IsShanghai(header.Number, header.Time, types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion) {
+	if sim.chainConfig.IsShanghai(header.Number, header.Time, arbOSVersion) {
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
 	if requests != nil {

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -208,7 +208,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if precompiles != nil {
 		evm.SetPrecompiles(precompiles)
 	}
-	if sim.chainConfig.IsPrague(header.Number, header.Time, arbOSVersion) || sim.chainConfig.IsVerkle(header.Number, header.Time) {
+	if sim.chainConfig.IsPrague(header.Number, header.Time, parentArbOSVersion) || sim.chainConfig.IsVerkle(header.Number, header.Time) {
 		core.ProcessParentBlockHash(header.ParentHash, evm)
 	}
 	var allLogs []*types.Log
@@ -257,8 +257,8 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		callResults[i] = callRes
 	}
 	var requests [][]byte
-	// Process EIP-7685 requests
-	if sim.chainConfig.IsPrague(header.Number, header.Time, arbOSVersion) {
+	// Process EIP-7685 requests unless Arbitrum is enabled.
+	if !sim.chainConfig.IsArbitrum() && sim.chainConfig.IsPrague(header.Number, header.Time, parentArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110
 		if err := core.ParseDepositLogs(&requests, allLogs, sim.chainConfig); err != nil {
@@ -271,11 +271,11 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	}
 	header.Root = sim.state.IntermediateRoot(true)
 	header.GasUsed = gasUsed
-	if sim.chainConfig.IsCancun(header.Number, header.Time, arbOSVersion) {
+	if sim.chainConfig.IsCancun(header.Number, header.Time, parentArbOSVersion) {
 		header.BlobGasUsed = &blobGasUsed
 	}
 	var withdrawals types.Withdrawals
-	if sim.chainConfig.IsShanghai(header.Number, header.Time, arbOSVersion) {
+	if sim.chainConfig.IsShanghai(header.Number, header.Time, parentArbOSVersion) {
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
 	if requests != nil {

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -168,9 +168,10 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 			}
 		}
 	}
-	if sim.chainConfig.IsCancun(header.Number, header.Time, types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion) {
+	arbOSVersion := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
+	if sim.chainConfig.IsCancun(header.Number, header.Time, arbOSVersion) {
 		var excess uint64
-		if sim.chainConfig.IsCancun(parent.Number, parent.Time, types.DeserializeHeaderExtraInformation(parent).ArbOSFormatVersion) {
+		if sim.chainConfig.IsCancun(parent.Number, parent.Time, arbOSVersion) {
 			excess = eip4844.CalcExcessBlobGas(sim.chainConfig, parent, header.Time)
 		}
 		header.ExcessBlobGas = &excess
@@ -206,7 +207,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if precompiles != nil {
 		evm.SetPrecompiles(precompiles)
 	}
-	if sim.chainConfig.IsPrague(header.Number, header.Time) || sim.chainConfig.IsVerkle(header.Number, header.Time) {
+	if sim.chainConfig.IsPrague(header.Number, header.Time, arbOSVersion) || sim.chainConfig.IsVerkle(header.Number, header.Time) {
 		core.ProcessParentBlockHash(header.ParentHash, evm)
 	}
 	var allLogs []*types.Log
@@ -256,7 +257,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	}
 	var requests [][]byte
 	// Process EIP-7685 requests
-	if sim.chainConfig.IsPrague(header.Number, header.Time) {
+	if sim.chainConfig.IsPrague(header.Number, header.Time, arbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110
 		if err := core.ParseDepositLogs(&requests, allLogs, sim.chainConfig); err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -252,7 +252,7 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 	}
 	// Note the passed coinbase may be different with header.Coinbase.
 	return &environment{
-		signer:   types.MakeSigner(miner.chainConfig, header.Number, header.Time),
+		signer:   types.MakeSigner(miner.chainConfig, header.Number, header.Time, params.MaxArbosVersionSupported),
 		state:    state,
 		coinbase: coinbase,
 		header:   header,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -120,7 +120,9 @@ func (miner *Miner) generateWork(params *generateParams, witness bool) *newPaylo
 
 	// Collect consensus-layer requests if Prague is enabled.
 	var requests [][]byte
-	if miner.chainConfig.IsPrague(work.header.Number, work.header.Time) {
+	parent := miner.chain.CurrentBlock()
+	prevArbOSVersion := types.DeserializeHeaderExtraInformation(parent).ArbOSFormatVersion
+	if miner.chainConfig.IsPrague(work.header.Number, work.header.Time, prevArbOSVersion) {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		if err := core.ParseDepositLogs(&requests, allLogs, miner.chainConfig); err != nil {
@@ -228,7 +230,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	if header.ParentBeaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)
 	}
-	if miner.chainConfig.IsPrague(header.Number, header.Time) {
+	if miner.chainConfig.IsPrague(header.Number, header.Time, prevArbosVersion) {
 		core.ProcessParentBlockHash(header.ParentHash, env.evm)
 	}
 	return env, nil

--- a/params/config.go
+++ b/params/config.go
@@ -621,7 +621,10 @@ func (c *ChainConfig) IsCancun(num *big.Int, time uint64, currentArbosVersion ui
 }
 
 // IsPrague returns whether time is either equal to the Prague fork time or greater.
-func (c *ChainConfig) IsPrague(num *big.Int, time uint64) bool {
+func (c *ChainConfig) IsPrague(num *big.Int, time uint64, currentArbosVersion uint64) bool {
+	if c.IsArbitrum() {
+		return currentArbosVersion >= ArbosVersion_40
+	}
 	return c.IsLondon(num) && isTimestampForked(c.PragueTime, time)
 }
 
@@ -884,7 +887,7 @@ func (c *ChainConfig) LatestFork(time uint64, currentArbosVersion uint64) forks.
 	switch {
 	case c.IsOsaka(london, time):
 		return forks.Osaka
-	case c.IsPrague(london, time):
+	case c.IsPrague(london, time, currentArbosVersion):
 		return forks.Prague
 	case c.IsCancun(london, time, currentArbosVersion):
 		return forks.Cancun
@@ -1069,7 +1072,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 		IsMerge:          isMerge,
 		IsShanghai:       isMerge && c.IsShanghai(num, timestamp, currentArbosVersion),
 		IsCancun:         isMerge && c.IsCancun(num, timestamp, currentArbosVersion),
-		IsPrague:         isMerge && c.IsPrague(num, timestamp),
+		IsPrague:         isMerge && c.IsPrague(num, timestamp, currentArbosVersion),
 		IsOsaka:          isMerge && c.IsOsaka(num, timestamp),
 		IsVerkle:         isVerkle,
 		IsEIP4762:        isVerkle,


### PR DESCRIPTION
This way we can enable the features for Prauge when the Arbos version is
upgraded on chain instead of at some particular block number or block time.

Part of: NIT-3139 and NIT-3173