### PR TITLE
Reverts #435

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -120,8 +120,8 @@ func CreateFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.D
 }
 
 type SyncProgressBackend interface {
-	SyncProgressMap() map[string]interface{}
-	BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error)
+	SyncProgressMap(ctx context.Context) map[string]interface{}
+	BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error)
 }
 
 func createRegisterAPIBackend(backend *Backend, filterConfig filters.Config, fallbackClientUrl string, fallbackClientTimeout time.Duration) (*filters.FilterSystem, error) {
@@ -205,17 +205,17 @@ func (a *APIBackend) GetBody(ctx context.Context, hash common.Hash, number rpc.B
 }
 
 // General Ethereum API
-func (a *APIBackend) SyncProgressMap() map[string]interface{} {
+func (a *APIBackend) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	if a.sync == nil {
 		res := make(map[string]interface{})
 		res["error"] = "sync object not set in apibackend"
 		return res
 	}
-	return a.sync.SyncProgressMap()
+	return a.sync.SyncProgressMap(ctx)
 }
 
 func (a *APIBackend) SyncProgress() ethereum.SyncProgress {
-	progress := a.SyncProgressMap()
+	progress := a.SyncProgressMap(context.Background())
 
 	if len(progress) == 0 {
 		return ethereum.SyncProgress{}
@@ -496,8 +496,8 @@ func (a *APIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.
 	return nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
-func (a *APIBackend) BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error) {
-	return a.sync.BlockMetadataByNumber(blockNum)
+func (a *APIBackend) BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error) {
+	return a.sync.BlockMetadataByNumber(ctx, blockNum)
 }
 
 func StateAndHeaderFromHeader(ctx context.Context, chainDb ethdb.Database, bc *core.BlockChain, maxRecreateStateDepth int64, header *types.Header, err error) (*state.StateDB, *types.Header, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -182,7 +182,7 @@ func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash r
 	return nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
-func (b *EthAPIBackend) BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error) {
+func (b *EthAPIBackend) BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error) {
 	return nil, nil
 }
 
@@ -354,7 +354,7 @@ func (b *EthAPIBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.S
 	return b.eth.txPool.SubscribeTransactions(ch, true)
 }
 
-func (b *EthAPIBackend) SyncProgressMap() map[string]interface{} {
+func (b *EthAPIBackend) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	progress := b.eth.Downloader().Progress()
 	return progress.ToMap()
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -152,8 +152,8 @@ func (api *EthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
 // - highestBlock:  block number of the highest block header this node has received from peers
 // - pulledStates:  number of state entries processed until now
 // - knownStates:   number of known state entries that still need to be pulled
-func (api *EthereumAPI) Syncing() (interface{}, error) {
-	progress := api.b.SyncProgressMap()
+func (api *EthereumAPI) Syncing(ctx context.Context) (interface{}, error) {
+	progress := api.b.SyncProgressMap(ctx)
 
 	if len(progress) == 0 {
 		return false, nil
@@ -1653,7 +1653,7 @@ func marshalReceipt(ctx context.Context, receipt *types.Receipt, blockHash commo
 
 		// If blockMetadata exists for the block containing this tx, then we will determine if it was timeboosted or not
 		// and add that info to the receipt object
-		blockMetadata, err := backend.BlockMetadataByNumber(blockNumber)
+		blockMetadata, err := backend.BlockMetadataByNumber(ctx, blockNumber)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -535,7 +535,7 @@ func (b testBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.
 	}
 	panic("unknown type rpc.BlockNumberOrHash")
 }
-func (b testBackend) BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error) {
+func (b testBackend) BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error) {
 	return nil, nil
 }
 func (b testBackend) GetBody(ctx context.Context, hash common.Hash, number rpc.BlockNumber) (*types.Body, error) {
@@ -628,7 +628,7 @@ func (b testBackend) FallbackClient() types.FallbackClient {
 	return nil
 }
 
-func (b testBackend) SyncProgressMap() map[string]interface{} {
+func (b testBackend) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	return map[string]interface{}{}
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -44,7 +44,7 @@ type Backend interface {
 
 	// General Ethereum API
 	SyncProgress() ethereum.SyncProgress
-	SyncProgressMap() map[string]interface{}
+	SyncProgressMap(ctx context.Context) map[string]interface{}
 
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
@@ -67,7 +67,7 @@ type Backend interface {
 	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
-	BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error) // This queries SyncProgressBackend (execution's syncMonitor) to fetch blockMetadata for a given block number
+	BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error) // This queries SyncProgressBackend (execution's syncMonitor) to fetch blockMetadata for a given block number
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
 	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	Pending() (*types.Block, types.Receipts, *state.StateDB)

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -354,7 +354,7 @@ func (b *backendMock) BlockByHash(ctx context.Context, hash common.Hash) (*types
 func (b *backendMock) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
 	return nil, nil
 }
-func (b *backendMock) BlockMetadataByNumber(blockNum uint64) (common.BlockMetadata, error) {
+func (b *backendMock) BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error) {
 	return nil, nil
 }
 func (b *backendMock) GetBody(ctx context.Context, hash common.Hash, number rpc.BlockNumber) (*types.Body, error) {
@@ -410,6 +410,6 @@ func (b *backendMock) FallbackClient() types.FallbackClient {
 	return nil
 }
 
-func (b *backendMock) SyncProgressMap() map[string]interface{} {
+func (b *backendMock) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	return nil
 }


### PR DESCRIPTION
Reverts https://github.com/OffchainLabs/go-ethereum/pull/435

Brings back Context as an argument to some functions related to SyncProgressBackend.

