### PR TITLE
flush batch during chain rewinding, make head rewind block limit configurable

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -595,6 +595,13 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 				rawdb.DeleteHeader(batch, hash, num)
 			}
 			rawdb.DeleteCanonicalHash(batch, num)
+
+			// flush after each deleted header and its side forks
+			// on the first iteration (when origin==true) len(nums) can be considerable
+			if batch.ValueSize() >= ethdb.IdealBatchSize {
+				batch.Write()
+				batch.Reset()
+			}
 		}
 	}
 	// Flush all accumulated deletions.


### PR DESCRIPTION
Part of NIT-3198

This PR: 
* adds write batch flushing during chain rewinding - prevents possible panic triggered by batch size exceeding 4GB
* adds `HeadRewindBlocksLimit` config option to `core.CachingConfig` - if set, overwrites default geth rewind limit counted in blocks; geth default is `90000` blocks what e.g. might not be enough for nitro node to reach previously committed state root