### PR TITLE
use cloudflare bn256 implementation also for wasm build

### DIFF
--- a/crypto/bn256/bn256_fast.go
+++ b/crypto/bn256/bn256_fast.go
@@ -3,7 +3,7 @@
 // in the LICENSE file.
 
 //go:build amd64 || arm64 || wasm
-// +build amd64 arm64 wasm wasm
+// +build amd64 arm64 wasm
 
 // Package bn256 implements the Optimal Ate pairing over a 256-bit Barreto-Naehrig curve.
 package bn256

--- a/crypto/bn256/bn256_fast.go
+++ b/crypto/bn256/bn256_fast.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-//go:build amd64 || arm64
-// +build amd64 arm64
+//go:build amd64 || arm64 || wasm
+// +build amd64 arm64 wasm wasm
 
 // Package bn256 implements the Optimal Ate pairing over a 256-bit Barreto-Naehrig curve.
 package bn256

--- a/crypto/bn256/bn256_slow.go
+++ b/crypto/bn256/bn256_slow.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-//go:build !amd64 && !arm64
-// +build !amd64,!arm64
+//go:build !amd64 && !arm64 && !wasm
+// +build !amd64,!arm64,!wasm
 
 // Package bn256 implements the Optimal Ate pairing over a 256-bit Barreto-Naehrig curve.
 package bn256


### PR DESCRIPTION
Part of NIT-2641

bn256 libarary used by bn256* precompiles has two implementations, chosen by a build pragma. This PR enables cloudflare implementation for wasm, as it was previously only build and used for x86 and arm builds. It is a faster implementation and initial experiments suggest that it should render 2x savings in terms of number of arbitrator machine steps required to execute the precompiles.