### PR TITLE
Allow nitro nodes to forward requests based on block number to archive nodes

### DIFF
--- a/arbitrum/apibackend.go
+++ b/arbitrum/apibackend.go
@@ -48,8 +48,9 @@ type APIBackend struct {
 
 	dbForAPICalls ethdb.Database
 
-	fallbackClient types.FallbackClient
-	sync           SyncProgressBackend
+	fallbackClient        types.FallbackClient
+	archiveClientsManager *archiveFallbackClientsManager
+	sync                  SyncProgressBackend
 }
 
 type errorFilteredFallbackClient struct {
@@ -79,11 +80,11 @@ func (c *timeoutFallbackClient) CallContext(ctxIn context.Context, result interf
 	return c.impl.CallContext(ctx, result, method, args...)
 }
 
-func CreateFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.Duration) (types.FallbackClient, error) {
+func CreateFallbackClient(fallbackClientUrl string, fallbackClientTimeout time.Duration, isArchiveNode bool) (types.FallbackClient, error) {
 	if fallbackClientUrl == "" {
 		return nil, nil
 	}
-	if strings.HasPrefix(fallbackClientUrl, "error:") {
+	if !isArchiveNode && strings.HasPrefix(fallbackClientUrl, "error:") {
 		fields := strings.Split(fallbackClientUrl, ":")[1:]
 		errNumber, convErr := strconv.ParseInt(fields[0], 0, 0)
 		if convErr == nil {
@@ -124,8 +125,8 @@ type SyncProgressBackend interface {
 	BlockMetadataByNumber(ctx context.Context, blockNum uint64) (common.BlockMetadata, error)
 }
 
-func createRegisterAPIBackend(backend *Backend, filterConfig filters.Config, fallbackClientUrl string, fallbackClientTimeout time.Duration) (*filters.FilterSystem, error) {
-	fallbackClient, err := CreateFallbackClient(fallbackClientUrl, fallbackClientTimeout)
+func createRegisterAPIBackend(backend *Backend, filterConfig filters.Config, fallbackClientUrl string, fallbackClientTimeout time.Duration, archiveRedirects []ArchiveRedirectConfig) (*filters.FilterSystem, error) {
+	fallbackClient, err := CreateFallbackClient(fallbackClientUrl, fallbackClientTimeout, false)
 	if err != nil {
 		return nil, err
 	}
@@ -135,10 +136,18 @@ func createRegisterAPIBackend(backend *Backend, filterConfig filters.Config, fal
 	if tag != 0 || len(backend.chainDb.WasmTargets()) > 1 {
 		dbForAPICalls = rawdb.WrapDatabaseWithWasm(backend.chainDb, wasmStore, 0, []ethdb.WasmTarget{rawdb.LocalTarget()})
 	}
+	var archiveClientsManager *archiveFallbackClientsManager
+	if len(archiveRedirects) != 0 {
+		archiveClientsManager, err = newArchiveFallbackClientsManager(archiveRedirects)
+		if err != nil {
+			return nil, err
+		}
+	}
 	backend.apiBackend = &APIBackend{
-		b:              backend,
-		dbForAPICalls:  dbForAPICalls,
-		fallbackClient: fallbackClient,
+		b:                     backend,
+		dbForAPICalls:         dbForAPICalls,
+		fallbackClient:        fallbackClient,
+		archiveClientsManager: archiveClientsManager,
 	}
 	filterSystem := filters.NewFilterSystem(backend.apiBackend, filterConfig)
 	backend.stack.RegisterAPIs(backend.apiBackend.GetAPIs(filterSystem))
@@ -500,7 +509,7 @@ func (a *APIBackend) BlockMetadataByNumber(ctx context.Context, blockNum uint64)
 	return a.sync.BlockMetadataByNumber(ctx, blockNum)
 }
 
-func StateAndHeaderFromHeader(ctx context.Context, chainDb ethdb.Database, bc *core.BlockChain, maxRecreateStateDepth int64, header *types.Header, err error) (*state.StateDB, *types.Header, error) {
+func StateAndHeaderFromHeader(ctx context.Context, chainDb ethdb.Database, bc *core.BlockChain, maxRecreateStateDepth int64, header *types.Header, err error, archiveClientsManager *archiveFallbackClientsManager) (*state.StateDB, *types.Header, error) {
 	if err != nil {
 		return nil, header, err
 	}
@@ -509,6 +518,9 @@ func StateAndHeaderFromHeader(ctx context.Context, chainDb ethdb.Database, bc *c
 	}
 	if !bc.Config().IsArbitrumNitro(header.Number) {
 		return nil, header, types.ErrUseFallback
+	}
+	if archiveClientsManager != nil && header.Number.Uint64() <= archiveClientsManager.lastAvailableBlock() {
+		return nil, header, &types.ErrUseArchiveFallback{BlockNum: header.Number.Uint64()}
 	}
 	stateFor := func(db state.Database, snapshots *snapshot.Tree) func(header *types.Header) (*state.StateDB, StateReleaseFunc, error) {
 		return func(header *types.Header) (*state.StateDB, StateReleaseFunc, error) {
@@ -583,7 +595,7 @@ func StateAndHeaderFromHeader(ctx context.Context, chainDb ethdb.Database, bc *c
 
 func (a *APIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	header, err := a.HeaderByNumber(ctx, number)
-	return StateAndHeaderFromHeader(ctx, a.ChainDb(), a.b.arb.BlockChain(), a.b.config.MaxRecreateStateDepth, header, err)
+	return StateAndHeaderFromHeader(ctx, a.ChainDb(), a.b.arb.BlockChain(), a.b.config.MaxRecreateStateDepth, header, err, a.archiveClientsManager)
 }
 
 func (a *APIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
@@ -594,7 +606,7 @@ func (a *APIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOr
 	if ishash && header != nil && header.Number.Cmp(bc.CurrentBlock().Number) > 0 && bc.GetCanonicalHash(header.Number.Uint64()) != hash {
 		return nil, nil, errors.New("requested block ahead of current block and the hash is not currently canonical")
 	}
-	return StateAndHeaderFromHeader(ctx, a.ChainDb(), a.b.arb.BlockChain(), a.b.config.MaxRecreateStateDepth, header, err)
+	return StateAndHeaderFromHeader(ctx, a.ChainDb(), a.b.arb.BlockChain(), a.b.config.MaxRecreateStateDepth, header, err, a.archiveClientsManager)
 }
 
 func (a *APIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool) (statedb *state.StateDB, release tracers.StateReleaseFunc, err error) {
@@ -729,4 +741,8 @@ func (a *APIBackend) Pending() (*types.Block, types.Receipts, *state.StateDB) {
 
 func (a *APIBackend) FallbackClient() types.FallbackClient {
 	return a.fallbackClient
+}
+
+func (a *APIBackend) ArchiveFallbackClient(blockNum uint64) types.FallbackClient {
+	return a.archiveClientsManager.fallbackClient(blockNum)
 }

--- a/arbitrum/archivefallbackclients.go
+++ b/arbitrum/archivefallbackclients.go
@@ -1,0 +1,71 @@
+package arbitrum
+
+import (
+	"math/rand"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type lastBlockAndClient struct {
+	lastBlock uint64
+	client    types.FallbackClient
+}
+
+type archiveFallbackClientsManager struct {
+	lastBlockAndClients []*lastBlockAndClient
+}
+
+func newArchiveFallbackClientsManager(archiveRedirects []ArchiveRedirectConfig) (*archiveFallbackClientsManager, error) {
+	manager := &archiveFallbackClientsManager{}
+	for _, archiveConfig := range archiveRedirects {
+		fallbackClient, err := CreateFallbackClient(archiveConfig.URL, archiveConfig.Timeout, true)
+		if err != nil {
+			return nil, err
+		}
+		if fallbackClient == nil {
+			continue
+		}
+		manager.lastBlockAndClients = append(manager.lastBlockAndClients, &lastBlockAndClient{
+			lastBlock: archiveConfig.LastBlock,
+			client:    fallbackClient,
+		})
+	}
+	if len(manager.lastBlockAndClients) == 0 {
+		return nil, nil
+	}
+	sort.Slice(manager.lastBlockAndClients, func(i, j int) bool {
+		return manager.lastBlockAndClients[i].lastBlock > manager.lastBlockAndClients[j].lastBlock
+	})
+	return manager, nil
+}
+
+func (a *archiveFallbackClientsManager) lastAvailableBlock() uint64 {
+	return a.lastBlockAndClients[0].lastBlock
+}
+
+func (a *archiveFallbackClientsManager) validPool(blockNum uint64) int {
+	// First find which clients have this block using binary search
+	s, f := 0, len(a.lastBlockAndClients)-1
+	for s < f {
+		m := (s + f + 1) / 2
+		if blockNum <= a.lastBlockAndClients[m].lastBlock {
+			s = m
+		} else {
+			f = m - 1
+		}
+	}
+	if blockNum > a.lastBlockAndClients[s].lastBlock {
+		return -1
+	}
+	return s
+}
+
+func (a *archiveFallbackClientsManager) fallbackClient(blockNum uint64) types.FallbackClient {
+	pos := a.validPool(blockNum)
+	if pos == -1 {
+		return nil
+	}
+	// Pick a random client form the pool
+	return a.lastBlockAndClients[rand.Intn(pos+1)].client
+}

--- a/arbitrum/archivefallbackclients_test.go
+++ b/arbitrum/archivefallbackclients_test.go
@@ -1,0 +1,53 @@
+package arbitrum
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestArchiveFallbackClientsManager(t *testing.T) {
+	manager := archiveFallbackClientsManager{}
+	lastBlocks := []uint64{100, 150, 200, 250, 500}
+	for i := 0; i < 5; i++ {
+		manager.lastBlockAndClients = append(manager.lastBlockAndClients, &lastBlockAndClient{lastBlock: lastBlocks[i]})
+	}
+	sort.Slice(manager.lastBlockAndClients, func(i, j int) bool {
+		return manager.lastBlockAndClients[i].lastBlock > manager.lastBlockAndClients[j].lastBlock
+	})
+
+	lastAvailableBlock := manager.lastAvailableBlock()
+	if lastAvailableBlock != lastBlocks[len(lastBlocks)-1] {
+		t.Fatalf("unexpected lastAvailableBlock. Want: %d, Got: %d", lastBlocks[len(lastBlocks)-1], lastAvailableBlock)
+	}
+
+	// Clients are sorted in the descending order of their last-block values
+	// Every client should be in the valid pool
+	pos := manager.validPool(100)
+	if pos != 4 {
+		t.Fatalf("unexpected number of clients in valid pool. Want: 4, Got: %d", pos)
+	}
+
+	// Last client wont be in the valid pool
+	pos = manager.validPool(140)
+	if pos != 3 {
+		t.Fatalf("unexpected number of clients in valid pool. Want: 3, Got: %d", pos)
+	}
+
+	// Only first two will be in the valid pool
+	pos = manager.validPool(240)
+	if pos != 1 {
+		t.Fatalf("unexpected number of clients in valid pool. Want: 1, Got: %d", pos)
+	}
+
+	// Only first will be in the valid pool
+	pos = manager.validPool(440)
+	if pos != 0 {
+		t.Fatalf("unexpected number of clients in valid pool. Want: 0, Got: %d", pos)
+	}
+
+	// No client is in the valid pool
+	pos = manager.validPool(540)
+	if pos != -1 {
+		t.Fatalf("unexpected number of clients in valid pool. Want: -1, Got: %d", pos)
+	}
+}

--- a/arbitrum/backend.go
+++ b/arbitrum/backend.go
@@ -65,7 +65,7 @@ func NewBackend(stack *node.Node, config *Config, chainDb ethdb.Database, publis
 	}
 
 	backend.bloomIndexer.Start(backend.arb.BlockChain())
-	filterSystem, err := createRegisterAPIBackend(backend, filterConfig, config.ClassicRedirect, config.ClassicRedirectTimeout)
+	filterSystem, err := createRegisterAPIBackend(backend, filterConfig, config.ClassicRedirect, config.ClassicRedirectTimeout, config.ArchiveRedirects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -40,6 +41,14 @@ func (f fallbackError) ErrorCode() int { return fallbackErrorCode }
 func (f fallbackError) Error() string  { return fallbackErrorMsg }
 
 var ErrUseFallback = fallbackError{}
+
+type ErrUseArchiveFallback struct {
+	BlockNum uint64
+}
+
+func (e *ErrUseArchiveFallback) Error() string {
+	return fmt.Sprintf("use archive fallback client for block %d", e.BlockNum)
+}
 
 type FallbackClient interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -441,3 +441,7 @@ func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Blo
 func (b *EthAPIBackend) FallbackClient() types.FallbackClient {
 	return nil
 }
+
+func (b *EthAPIBackend) ArchiveFallbackClient(_ uint64) types.FallbackClient {
+	return nil
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -57,10 +57,14 @@ var (
 )
 
 func fallbackClientFor(b Backend, err error) types.FallbackClient {
-	if !errors.Is(err, types.ErrUseFallback) {
-		return nil
+	if errors.Is(err, types.ErrUseFallback) {
+		return b.FallbackClient()
 	}
-	return b.FallbackClient()
+	var archiveErr *types.ErrUseArchiveFallback
+	if errors.As(err, &archiveErr) {
+		return b.ArchiveFallbackClient(archiveErr.BlockNum)
+	}
+	return nil
 }
 
 // EthereumAPI provides an API to access Ethereum related information.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -628,6 +628,10 @@ func (b testBackend) FallbackClient() types.FallbackClient {
 	return nil
 }
 
+func (b testBackend) ArchiveFallbackClient(_ uint64) types.FallbackClient {
+	return nil
+}
+
 func (b testBackend) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	return map[string]interface{}{}
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -41,6 +41,7 @@ import (
 // both full and light clients) with access to necessary functions.
 type Backend interface {
 	FallbackClient() types.FallbackClient
+	ArchiveFallbackClient(blockNum uint64) types.FallbackClient
 
 	// General Ethereum API
 	SyncProgress() ethereum.SyncProgress

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -410,6 +410,10 @@ func (b *backendMock) FallbackClient() types.FallbackClient {
 	return nil
 }
 
+func (b *backendMock) ArchiveFallbackClient(_ uint64) types.FallbackClient {
+	return nil
+}
+
 func (b *backendMock) SyncProgressMap(ctx context.Context) map[string]interface{} {
 	return nil
 }


### PR DESCRIPTION
This PR allows forwarding of requests to archive nodes based on block numbers thus allowing splitting of archive databases for better manageability. Configured via `archive-redirects` option which is a list of `ArchiveRedirectConfig` consisting of fields- `url`, `timeout` and `last-block` (block up to which this archive node can service requests). 

User can also configure via command line using `archive-redirects-list` which is a string that should be in json format consisting array of above archive node configs.
```
--execution.rpc.archive-redirects-list=`[{"url": "<>", "timeout":<in nano seconds>, "last-block": 100}, {"url":"<>}]`
```

part of NIT-3211