### PR TITLE
Disable the i386 lint action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   lint:
+    if: false # not supported on OffchainLabs fork, ci.yml is used instead
     name: Lint
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
This was added at some point, but we don't have self-hosted CI runners in the OffchainLabs pool of runners, so, these actions never get picked up.

Linting is already covered in ci.yml, anyway.