### PR TITLE
change synchronisation in hashdb commit to allow concurrent reads

### DIFF
--- a/triedb/hashdb/cleaner_arbitrum.go
+++ b/triedb/hashdb/cleaner_arbitrum.go
@@ -1,0 +1,52 @@
+package hashdb
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+)
+
+type delayedCleaner struct {
+	db      *Database
+	cleaner *cleaner
+
+	hashes []common.Hash // to-be-deleted hashes
+}
+
+func newDelayedCleaner(db *Database) *delayedCleaner {
+	return &delayedCleaner{
+		db:      db,
+		cleaner: &cleaner{db: db},
+	}
+}
+
+// Put can be called holding read lock
+// Write lock is not required here as Put doesn't modify dirties
+// The value put is ignored as it can be read later on from dirties
+func (c *delayedCleaner) Put(key []byte, _ []byte) error {
+	hash := common.BytesToHash(key)
+	// If the node does not exist, we're done on this path
+	_, ok := c.db.dirties[hash]
+	if !ok {
+		return nil
+	}
+	// add key to to-be-deleted keys
+	c.hashes = append(c.hashes, hash)
+	return nil
+}
+
+func (c *delayedCleaner) Delete(key []byte) error {
+	panic("not implemented")
+}
+
+// Clean removes the buffered to-be-deleted keys from dirties
+// Write lock must be held by the caller
+func (c *delayedCleaner) Clean() {
+	for _, hash := range c.hashes {
+		node, ok := c.db.dirties[hash]
+		if !ok {
+			// node no longer in dirties
+			continue
+		}
+		rawdb.WriteLegacyTrieNode(c.cleaner, hash, node.node)
+	}
+}

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -445,7 +445,7 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	rLocked = false
 	db.lock.RUnlock()
 
-	// acquire write lock for the uncacher to remove commited nodes from dirties
+	// acquire write lock for the uncacher to remove committed nodes from dirties
 	db.lock.Lock()
 	defer db.lock.Unlock()
 


### PR DESCRIPTION
This PR modifies hashdb.commit operation:
* nodes removal from dirties is delayed until all writes to disk are performed
* read lock is used for the fist part of commit operation
* hashdb write lock is acquired only when removing nodes from dirties

part of NIT-3414