### PR TITLE
Fix eth_simulateV1

### DIFF
--- a/core/types/arb_types.go
+++ b/core/types/arb_types.go
@@ -552,7 +552,7 @@ func (info HeaderInfo) UpdateHeaderWithInfo(header *Header) {
 }
 
 func DeserializeHeaderExtraInformation(header *Header) HeaderInfo {
-	if header == nil || header.BaseFee == nil || header.BaseFee.Sign() == 0 || len(header.Extra) != 32 || header.Difficulty.Cmp(common.Big1) != 0 {
+	if header == nil || header.BaseFee == nil || len(header.Extra) != 32 || header.Difficulty.Cmp(common.Big1) != 0 {
 		// imported blocks have no base fee
 		// The genesis block doesn't have an ArbOS encoded extra field
 		return HeaderInfo{}

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -412,7 +412,6 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 			Difficulty:       header.Difficulty,
 			GasLimit:         header.GasLimit,
 			MixDigest:        header.MixDigest,
-			BaseFee:          header.BaseFee,
 			Extra:            header.Extra,
 			WithdrawalsHash:  withdrawalsHash,
 			ParentBeaconRoot: parentBeaconRoot,

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -411,6 +411,9 @@ func (sim *simulator) makeHeaders(blocks []simBlock) ([]*types.Header, error) {
 			Coinbase:         header.Coinbase,
 			Difficulty:       header.Difficulty,
 			GasLimit:         header.GasLimit,
+			MixDigest:        header.MixDigest,
+			BaseFee:          header.BaseFee,
+			Extra:            header.Extra,
 			WithdrawalsHash:  withdrawalsHash,
 			ParentBeaconRoot: parentBeaconRoot,
 		})


### PR DESCRIPTION
Related to NIT-3401

eth_simulateV1 was recently added in geth, this PR make sure that all the information is propagated properly so that the same call works for arb chains as well

Pulled in https://github.com/OffchainLabs/nitro/pull/3304
