### PR TITLE
Add hash scheme as default for arbitrum eth config

### DIFF
--- a/arbitrum/config.go
+++ b/arbitrum/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	flag "github.com/spf13/pflag"
 )
@@ -119,4 +120,5 @@ var DefaultConfig = Config{
 		TimeoutQueueBound: 512,
 	},
 	BlockRedirectsList: "default",
+	StateScheme:        rawdb.HashScheme,
 }


### PR DESCRIPTION
If node starts with empty db (eg syncing sepolia from genesis) will start by default with Pathdb chosen, so to avoid that adding hash scheme as default here.