### PR TITLE
Instrument LOG0-LOG4 gas function

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -263,9 +263,14 @@ func makeGasLog(n uint64) gasFunc {
 			return multigas.ZeroGas(), 0, err
 		}
 
+		// Base LOG operation considered as computation.
+		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 		if overflow = multiGas.SafeIncrement(multigas.ResourceKindComputation, params.LogGas); overflow {
 			return multigas.ZeroGas(), 0, ErrGasUintOverflow
 		}
+
+		// LOG topic operations considered as computation.
+		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 		if overflow = multiGas.SafeIncrement(multigas.ResourceKindComputation, n*params.LogTopicGas); overflow {
 			return multigas.ZeroGas(), 0, ErrGasUintOverflow
 		}
@@ -274,6 +279,8 @@ func makeGasLog(n uint64) gasFunc {
 		if memorySizeGas, overflow = math.SafeMul(requestedSize, params.LogDataGas); overflow {
 			return multigas.ZeroGas(), 0, ErrGasUintOverflow
 		}
+		// Event log data considered as history growth.
+		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 		if overflow = multiGas.SafeIncrement(multigas.ResourceKindHistoryGrowth, memorySizeGas); overflow {
 			return multigas.ZeroGas(), 0, ErrGasUintOverflow
 		}

--- a/core/vm/operations_gas_test.go
+++ b/core/vm/operations_gas_test.go
@@ -1258,6 +1258,9 @@ func TestGasSelfdestructEIP4762(t *testing.T) {
 
 	if *multiGas != *expectedMultiGas {
 		t.Errorf("Expected multi gas %d, got %d", expectedMultiGas, multiGas)
+	}
+}
+
 // Base LOG0-LOG4 gas function test
 func TestMakeGasLog(t *testing.T) {
 	for n := uint64(0); n <= 4; n++ {


### PR DESCRIPTION
For NIT-3481

Instrument  LOG0-LOG4 opcodes with multigas calculations:
- [x] Base `makeGasLog` func

Note: waits https://github.com/OffchainLabs/go-ethereum/pull/486 to be merged, temporary points on `instrument_call_gas_func` branch