### PR TITLE
Update gasFunc signature to return only multi-dimensional gas

### DIFF
--- a/arbitrum/multigas/resources.go
+++ b/arbitrum/multigas/resources.go
@@ -36,6 +36,11 @@ func NewMultiGas(kind ResourceKind, amount uint64) *MultiGas {
 	return mg
 }
 
+// UnknownGas returns a MultiGas initialized with unknown gas.
+func UnknownGas(amount uint64) *MultiGas {
+	return NewMultiGas(ResourceKindUnknown, amount)
+}
+
 // ComputationGas returns a MultiGas initialized with computation gas.
 func ComputationGas(amount uint64) *MultiGas {
 	return NewMultiGas(ResourceKindComputation, amount)

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -42,12 +42,13 @@ func TestMemoryGasCost(t *testing.T) {
 		{0x1fffffffe1, 0, true},
 	}
 	for i, tt := range tests {
-		_, v, err := memoryGasCost(&Memory{}, tt.size)
+		multiGas, err := memoryGasCost(&Memory{}, tt.size)
+		gas := multiGas.SingleGas()
 		if (err == ErrGasUintOverflow) != tt.overflow {
 			t.Errorf("test %d: overflow mismatch: have %v, want %v", i, err == ErrGasUintOverflow, tt.overflow)
 		}
-		if v != tt.cost {
-			t.Errorf("test %d: gas cost mismatch: have %v, want %v", i, v, tt.cost)
+		if gas != tt.cost {
+			t.Errorf("test %d: gas cost mismatch: have %v, want %v", i, gas, tt.cost)
 		}
 	}
 }

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -879,10 +879,10 @@ func TestOpMCopy(t *testing.T) {
 		}
 		// and the dynamic cost
 		var haveGas uint64
-		if _, dynamicCost, err := gasMcopy(evm, nil, stack, mem, memorySize); err != nil {
+		if multiGas, err := gasMcopy(evm, nil, stack, mem, memorySize); err != nil {
 			t.Error(err)
 		} else {
-			haveGas = GasFastestStep + dynamicCost
+			haveGas = GasFastestStep + multiGas.SingleGas()
 		}
 		// Expand mem
 		if memorySize > 0 {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -288,8 +288,8 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 			// Consume the gas and return an error if not enough gas is available.
 			// cost is explicitly set so that the capture state defer method can get the proper cost
-			var dynamicCost uint64
-			_, dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
+			multiGas, err := operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
+			dynamicCost := multiGas.SingleGas()
 			cost += dynamicCost // for tracing
 			if err != nil {
 				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -26,7 +26,7 @@ import (
 type (
 	executionFunc func(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error)
 	// last parameter is the requested memory size as a uint64
-	// gasFunc returns multi-dimensional gas usage (MultiGas) and single-dimensional gas (uint64)
+	// gasFunc returns multi-dimensional gas usage (that can be converted to single-dimensional gas)
 	gasFunc func(*EVM, *Contract, *Stack, *Memory, uint64) (*multigas.MultiGas, error)
 	// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
 	memorySizeFunc func(*Stack) (size uint64, overflow bool)

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -27,7 +27,7 @@ type (
 	executionFunc func(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error)
 	// last parameter is the requested memory size as a uint64
 	// gasFunc returns multi-dimensional gas usage (MultiGas) and single-dimensional gas (uint64)
-	gasFunc func(*EVM, *Contract, *Stack, *Memory, uint64) (*multigas.MultiGas, uint64, error)
+	gasFunc func(*EVM, *Contract, *Stack, *Memory, uint64) (*multigas.MultiGas, error)
 	// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
 	memorySizeFunc func(*Stack) (size uint64, overflow bool)
 )

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -21,17 +21,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/arbitrum/multigas"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
 
 func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
-	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 		// If we fail the minimum gas availability invariant, fail (0)
 		if contract.Gas <= params.SstoreSentryGasEIP2200 {
-			return multigas.ZeroGas(), 0, errors.New("not enough gas for reentrancy sentry")
+			return multigas.ZeroGas(), errors.New("not enough gas for reentrancy sentry")
 		}
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (
@@ -58,8 +57,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			// Warm slot access considered as storage access.
 			// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 			multiGas.SafeIncrement(multigas.ResourceKindStorageAccess, params.WarmStorageReadCostEIP2929)
-			singleGas := multiGas.SingleGas()
-			return multiGas, singleGas, nil // SLOAD_GAS
+			return multiGas, nil // SLOAD_GAS
 		}
 		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 		if original == current {
@@ -67,8 +65,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 				// Creating a new slot considered as storage growth.
 				// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 				multiGas.SafeIncrement(multigas.ResourceKindStorageGrowth, params.SstoreSetGasEIP2200)
-				singleGas := multiGas.SingleGas()
-				return multiGas, singleGas, nil
+				return multiGas, nil
 			}
 			if value == (common.Hash{}) { // delete slot (2.1.2b)
 				evm.StateDB.AddRefund(clearingRefund)
@@ -79,8 +76,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			//  Storage slot writes (nonzero → zero) considered as storage access.
 			//  See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 			multiGas.SafeIncrement(multigas.ResourceKindStorageAccess, params.SstoreResetGasEIP2200-params.ColdSloadCostEIP2929)
-			singleGas := multiGas.SingleGas()
-			return multiGas, singleGas, nil // write existing slot (2.1.2)
+			return multiGas, nil // write existing slot (2.1.2)
 		}
 		if original != (common.Hash{}) {
 			if current == (common.Hash{}) { // recreate slot (2.2.1.1)
@@ -109,8 +105,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		// Warm slot access considered as storage access.
 		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 		multiGas.SafeIncrement(multigas.ResourceKindStorageAccess, params.WarmStorageReadCostEIP2929)
-		singleGas := multiGas.SingleGas()
-		return multiGas, singleGas, nil // dirty update (2.2)
+		return multiGas, nil // dirty update (2.2)
 	}
 }
 
@@ -119,7 +114,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 // whose storage is being read) is not yet in accessed_storage_keys,
 // charge 2100 gas and add the pair to accessed_storage_keys.
 // If the pair is already in accessed_storage_keys, charge 100 gas.
-func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
 	// Check slot presence in the access list
@@ -127,9 +122,11 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 		// If the caller cannot afford the cost, this change will be rolled back
 		// If he does afford it, we can skip checking the same thing later on, during execution
 		evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
-		return multigas.ZeroGas(), params.ColdSloadCostEIP2929, nil
+		// TODO(NIT-3484): Update multi dimensional gas here
+		return multigas.UnknownGas(params.ColdSloadCostEIP2929), nil
 	}
-	return multigas.ZeroGas(), params.WarmStorageReadCostEIP2929, nil
+	// TODO(NIT-3484): Update multi dimensional gas here
+	return multigas.UnknownGas(params.WarmStorageReadCostEIP2929), nil
 }
 
 // gasExtCodeCopyEIP2929 implements extcodecopy according to EIP-2929
@@ -137,25 +134,25 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 // > If the target is not in accessed_addresses,
 // > charge COLD_ACCOUNT_ACCESS_COST gas, and add the address to accessed_addresses.
 // > Otherwise, charge WARM_STORAGE_READ_COST gas.
-func gasExtCodeCopyEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+func gasExtCodeCopyEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 	// memory expansion first (dynamic part of pre-2929 implementation)
-	multiGas, gas, err := gasExtCodeCopy(evm, contract, stack, mem, memorySize)
+	multiGas, err := gasExtCodeCopy(evm, contract, stack, mem, memorySize)
 	if err != nil {
-		return multigas.ZeroGas(), 0, err
+		return multigas.ZeroGas(), err
 	}
 	addr := common.Address(stack.peek().Bytes20())
 	// Check slot presence in the access list
 	if !evm.StateDB.AddressInAccessList(addr) {
 		evm.StateDB.AddAddressToAccessList(addr)
 		var overflow bool
-		// TODO(NIT-3484): Update multi dimensional gas here
 		// We charge (cold-warm), since 'warm' is already charged as constantGas
-		if gas, overflow = math.SafeAdd(gas, params.ColdAccountAccessCostEIP2929-params.WarmStorageReadCostEIP2929); overflow {
-			return multigas.ZeroGas(), 0, ErrGasUintOverflow
+		// TODO(NIT-3484): Update multi dimensional gas here
+		if overflow = multiGas.SafeIncrement(multigas.ResourceKindUnknown, params.ColdAccountAccessCostEIP2929-params.WarmStorageReadCostEIP2929); overflow {
+			return multigas.ZeroGas(), ErrGasUintOverflow
 		}
-		return multiGas, gas, nil
+		return multiGas, nil
 	}
-	return multiGas, gas, nil
+	return multiGas, nil
 }
 
 // gasEip2929AccountCheck checks whether the first stack item (as address) is present in the access list.
@@ -165,20 +162,21 @@ func gasExtCodeCopyEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memo
 // - extcodehash,
 // - extcodesize,
 // - (ext) balance
-func gasEip2929AccountCheck(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+func gasEip2929AccountCheck(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 	addr := common.Address(stack.peek().Bytes20())
 	// Check slot presence in the access list
 	if !evm.StateDB.AddressInAccessList(addr) {
 		// If the caller cannot afford the cost, this change will be rolled back
 		evm.StateDB.AddAddressToAccessList(addr)
 		// The warm storage read cost is already charged as constantGas
-		return multigas.ZeroGas(), params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929, nil
+		// TODO(NIT-3484): Update multi dimensional gas here
+		return multigas.UnknownGas(params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929), nil
 	}
-	return multigas.ZeroGas(), 0, nil
+	return multigas.ZeroGas(), nil
 }
 
 func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) gasFunc {
-	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 		addr := common.Address(stack.Back(addressPosition).Bytes20())
 		// Check slot presence in the access list
 		warmAccess := evm.StateDB.AddressInAccessList(addr)
@@ -190,7 +188,7 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) g
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
 			if !contract.UseGas(coldCost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
-				return multigas.ZeroGas(), 0, ErrOutOfGas
+				return multigas.ZeroGas(), ErrOutOfGas
 			}
 		}
 		// Now call the old calculator, which takes into account
@@ -198,9 +196,9 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) g
 		// - transfer value
 		// - memory expansion
 		// - 63/64ths rule
-		multiGas, gas, err := oldCalculator(evm, contract, stack, mem, memorySize)
+		multiGas, err := oldCalculator(evm, contract, stack, mem, memorySize)
 		if warmAccess || err != nil {
-			return multiGas, gas, err
+			return multiGas, err
 		}
 		// In case of a cold access, we temporarily add the cold charge back, and also
 		// add it to the returned gas. By adding it to the return, it will be charged
@@ -211,11 +209,10 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) g
 		// Cold slot access considered as storage access.
 		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 		if overflow := multiGas.SafeIncrement(multigas.ResourceKindStorageAccess, coldCost); overflow {
-			return multigas.ZeroGas(), 0, ErrGasUintOverflow
+			return multigas.ZeroGas(), ErrGasUintOverflow
 		}
 
-		singleGas := multiGas.SingleGas()
-		return multiGas, singleGas, nil
+		return multiGas, nil
 	}
 }
 
@@ -249,7 +246,7 @@ var (
 
 // makeSelfdestructGasFn can create the selfdestruct dynamic gas function for EIP-2929 and EIP-3529
 func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
-	gasFunc := func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+	gasFunc := func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 		var (
 			multiGas = multigas.ZeroGas()
 			address  = common.Address(stack.peek().Bytes20())
@@ -270,8 +267,7 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 		if refundsEnabled && !evm.StateDB.HasSelfDestructed(contract.Address()) {
 			evm.StateDB.AddRefund(params.SelfdestructRefundGas)
 		}
-		singleGas := multiGas.SingleGas()
-		return multiGas, singleGas, nil
+		return multiGas, nil
 	}
 	return gasFunc
 }
@@ -284,7 +280,7 @@ var (
 )
 
 func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
-	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, uint64, error) {
+	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (*multigas.MultiGas, error) {
 		var (
 			multiGas = multigas.ZeroGas() // total dynamic gas used
 			addr     = common.Address(stack.Back(1).Bytes20())
@@ -299,7 +295,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
 			if !contract.UseGas(coldCost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
-				return multigas.ZeroGas(), 0, ErrOutOfGas
+				return multigas.ZeroGas(), ErrOutOfGas
 			}
 			// Cold slot access considered as storage access.
 			// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
@@ -316,7 +312,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 				cost = params.ColdAccountAccessCostEIP2929
 			}
 			if !contract.UseGas(cost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
-				return multigas.ZeroGas(), 0, ErrOutOfGas
+				return multigas.ZeroGas(), ErrOutOfGas
 			}
 
 			// Target address resolution considered as storage access.
@@ -329,9 +325,9 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 		// - transfer value
 		// - memory expansion
 		// - 63/64ths rule
-		multiOld, old, err := oldCalculator(evm, contract, stack, mem, memorySize)
+		multiOld, err := oldCalculator(evm, contract, stack, mem, memorySize)
 		if err != nil {
-			return multiOld, old, err
+			return multiOld, err
 		}
 
 		// Temporarily add the gas charge back to the contract and return value. By
@@ -342,10 +338,9 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 
 		var overflow bool
 		if multiGas, overflow = multiGas.SafeAdd(multiGas, multiOld); overflow {
-			return multigas.ZeroGas(), 0, ErrGasUintOverflow
+			return multigas.ZeroGas(), ErrGasUintOverflow
 		}
 
-		singleGas := multiGas.SingleGas()
-		return multiGas, singleGas, nil
+		return multiGas, nil
 	}
 }


### PR DESCRIPTION
For NIT-3543

- [x] Update the gasFunc API to return only `(*multigas.MultiGas, error)`
- [x] For uninstrumented methods, temporarily return `ResourceKindUnknown` (added TODO comments)