### PR TITLE
Correct multigas attribution for LOG0–LOG4

### DIFF
--- a/core/vm/operations_gas_test.go
+++ b/core/vm/operations_gas_test.go
@@ -1277,7 +1277,21 @@ func TestMakeGasLog(t *testing.T) {
 			t.Fatalf("Failed memoryGasCost: %v", err)
 		}
 
-		expectedMultiGas.SafeIncrement(multigas.ResourceKindComputation, params.LogGas+n*params.LogTopicGas)
+		// Base LOG op → computation
+		expectedMultiGas.SafeIncrement(multigas.ResourceKindComputation, params.LogGas)
+
+		// Per-topic split
+		const topicBytes = uint64(32)
+		topicHistPer := topicBytes * params.LogDataGas // e.g., 256
+		if params.LogTopicGas < topicHistPer {
+			t.Fatalf("invalid params: LogTopicGas < topicHistPer")
+		}
+		topicCompPer := params.LogTopicGas - topicHistPer
+
+		expectedMultiGas.SafeIncrement(multigas.ResourceKindHistoryGrowth, n*topicHistPer)
+		expectedMultiGas.SafeIncrement(multigas.ResourceKindComputation, n*topicCompPer)
+
+		// Data bytes → history growth
 		expectedMultiGas.SafeIncrement(multigas.ResourceKindHistoryGrowth, requestedSize*params.LogDataGas)
 
 		multiGas, err := makeGasLog(n)(evm, contract, stack, mem, memorySize)


### PR DESCRIPTION
Fixes NIT-3598

Correct multigas attribution for LOG0–LOG4

Split per-topic gas (375) into:
- 256 gas → HistoryGrowth (32 bytes * 8 gas/byte stored in history)
- 119 gas → Computation (bloom/hash work)

Keeps SingleGas identical to go-ethreum original cost while aligning attribution