### PR TITLE
Allow same prevTimestamp in eth_simulateV1

### DIFF
--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -450,7 +450,7 @@ func (sim *simulator) sanitizeChain(blocks []simBlock) ([]simBlock, error) {
 			block.BlockOverrides.Time = (*hexutil.Uint64)(&t)
 		} else {
 			t = uint64(*block.BlockOverrides.Time)
-			if t <= prevTimestamp {
+			if t < prevTimestamp {
 				return nil, &invalidBlockTimestampError{fmt.Sprintf("block timestamps must be in order: %d <= %d", t, prevTimestamp)}
 			}
 		}

--- a/internal/ethapi/simulate_test.go
+++ b/internal/ethapi/simulate_test.go
@@ -65,7 +65,7 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 			baseNumber:    10,
 			baseTimestamp: 50,
 			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(74)}}},
-			err:           "block timestamps must be in order: 74 <= 74",
+			expected:      []result{{number: 11, timestamp: 62}, {number: 12, timestamp: 74}, {number: 13, timestamp: 74}},
 		},
 		{
 			baseNumber:    10,
@@ -77,7 +77,7 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 			baseNumber:    10,
 			baseTimestamp: 50,
 			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(11), Time: newUint64(60)}}, {BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(72)}}},
-			err:           "block timestamps must be in order: 72 <= 72",
+			expected:      []result{{number: 11, timestamp: 60}, {number: 12, timestamp: 72}, {number: 13, timestamp: 72}},
 		},
 	} {
 		sim := &simulator{base: &types.Header{Number: big.NewInt(int64(tc.baseNumber)), Time: tc.baseTimestamp}}


### PR DESCRIPTION
Related to NIT-3646
Pulled in https://github.com/OffchainLabs/nitro/pull/3535
Fixes https://github.com/OffchainLabs/go-ethereum/issues/502

Fix eth_simulateV1 block time check to allow Arbitrum blocks with non-increasing timestamps.
The current t <= prevTimestamp requirement rejects valid historical Arbitrum blocks where timestamps are equal.
Relaxing this to t < prevTimestamp enables accurate multi-block simulations without breaking Ethereum behavior.