### PR TITLE
Optimize multi-gas function to avoid allocation

### DIFF
--- a/core/vm/gas_test.go
+++ b/core/vm/gas_test.go
@@ -36,7 +36,8 @@ func TestConstantMultiGas(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := constantMultiGas(tc.cost, tc.op); *got != *tc.want {
+			got := multigas.ZeroGas()
+			if addConstantMultiGas(got, tc.cost, tc.op); *got != *tc.want {
 				t.Errorf("wrong constant multigas: got %v, want %v", got, tc.want)
 			}
 		})

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -275,7 +275,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		} else {
 			contract.Gas -= cost
 		}
-		contract.UsedMultiGas, _ = contract.UsedMultiGas.SafeAdd(contract.UsedMultiGas, constantMultiGas(cost, op))
+		addConstantMultiGas(contract.UsedMultiGas, cost, op)
 
 		// All ops with a dynamic memory usage also has a dynamic gas cost.
 		var memorySize uint64


### PR DESCRIPTION
This has a significant impact on the EVM interpreter performance. This can be measured by running the runtime benchmarks:

    go test -bench=. ./core/vm/runtime/

Close NIT-3769