### PR TITLE
Skip block size cap for arbitrum chains

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -50,7 +50,8 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain) *Bloc
 // validated at this point.
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// check EIP 7934 RLP-encoded block size cap
-	if v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.MaxBlockSize {
+	// but skip for Arbitrum (since arbtrium does not need a block size cap)
+	if !v.config.IsArbitrum() && v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.MaxBlockSize {
 		return ErrBlockOversized
 	}
 	// Check whether the block is already imported.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -64,8 +64,9 @@ type environment struct {
 }
 
 // txFits reports whether the transaction fits into the block size limit.
+// Always true for Arbitrum (since arbtrium does not need a block size cap)
 func (env *environment) txFitsSize(tx *types.Transaction) bool {
-	return env.size+tx.Size() < params.MaxBlockSize-maxBlockSizeBufferZone
+	return env.evm.ChainConfig().IsArbitrum() || env.size+tx.Size() < params.MaxBlockSize-maxBlockSizeBufferZone
 }
 
 const (
@@ -114,8 +115,9 @@ func (miner *Miner) generateWork(genParam *generateParams, witness bool) *newPay
 	// Check withdrawals fit max block size.
 	// Due to the cap on withdrawal count, this can actually never happen, but we still need to
 	// check to ensure the CL notices there's a problem if the withdrawal cap is ever lifted.
+	// skip for Arbitrum (since arbtrium does not need a block size cap)
 	maxBlockSize := params.MaxBlockSize - maxBlockSizeBufferZone
-	if genParam.withdrawals.Size() > maxBlockSize {
+	if !miner.chainConfig.IsArbitrum() && genParam.withdrawals.Size() > maxBlockSize {
 		return &newPayloadResult{err: errors.New("withdrawals exceed max block size")}
 	}
 	// Also add size of withdrawals to work block size.


### PR DESCRIPTION
Related to NIT-3645
Pulled in https://github.com/OffchainLabs/nitro/pull/3544

EIP-7934 introduces a block bytesize limit intended to aid block propagation between nodes.

On Arbitrum, blocks are not propagated directly. Instead, nodes exchange limited messages, and each node reconstructs blocks independently. This means the block size cap is not relevant.

If we attempted to enforce this rule, issues would arise:

* A block must exist for every message.
* If a block is flagged as “invalid due to encoding,” we cannot simply discard it—we would instead need to generate a replacement empty block.
* In cases where `ProduceBlock` fails, `replay.wasm` would panic.

To avoid these problems, the block size cap check from EIP-7934 is disabled for Arbitrum chains.


