### PR TITLE
Skip EIP-7825 for arbitrum chains (moved into nitro)

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -183,7 +183,7 @@ func Transaction(ctx *cli.Context) error {
 		if chainConfig.IsShanghai(new(big.Int), 0, 0) && tx.To() == nil && len(tx.Data()) > int(chainConfig.MaxInitCodeSize()) {
 			r.Error = errors.New("max initcode size exceeded")
 		}
-		if chainConfig.IsOsaka(new(big.Int), 0) && tx.Gas() > params.MaxTxGas {
+		if !chainConfig.IsArbitrum() && chainConfig.IsOsaka(new(big.Int), 0) && tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
 			r.Error = errors.New("gas limit exceeds maximum")
 		}
 		results = append(results, r)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -259,7 +259,7 @@ func TestStateProcessorErrors(t *testing.T) {
 			// The EstimateGas API tests test this case.
 			{ // ErrGasLimitTooHigh
 				txs: []*types.Transaction{
-					makeTx(key1, 0, common.Address{}, big.NewInt(0), params.MaxTxGas+1, big.NewInt(875000000), nil),
+					makeTx(key1, 0, common.Address{}, big.NewInt(0), params.MaxTxGasRenamedForNitroMerges+1, big.NewInt(875000000), nil),
 				},
 				want: "could not apply tx 0 [0x16505812a6da0b0150593e4d4eb90190ba64816a04b27d19ca926ebd6aff8aa0]: transaction gas limit too high (cap: 16777216, tx: 16777217)",
 			},

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -541,9 +541,9 @@ func (st *stateTransition) preCheck() error {
 			return fmt.Errorf("%w (sender %v)", ErrEmptyAuthList, msg.From)
 		}
 	}
-	// Verify tx gas limit does not exceed EIP-7825 cap.
-	if isOsaka && msg.GasLimit > params.MaxTxGas {
-		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
+	// Verify tx gas limit does not exceed EIP-7825 cap. Skipped for arbitrum chains
+	if !st.evm.ChainConfig().IsArbitrum() && isOsaka && msg.GasLimit > params.MaxTxGasRenamedForNitroMerges {
+		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGasRenamedForNitroMerges, msg.GasLimit)
 	}
 	return st.buyGas()
 }

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1268,7 +1268,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 			if pool.chainconfig.IsOsaka(reset.newHead.Number, reset.newHead.Time) && !pool.chainconfig.IsOsaka(reset.oldHead.Number, reset.oldHead.Time) {
 				var hashes []common.Hash
 				pool.all.Range(func(hash common.Hash, tx *types.Transaction) bool {
-					if tx.Gas() > params.MaxTxGas {
+					if !pool.chainconfig.IsArbitrum() && tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
 						hashes = append(hashes, hash)
 					}
 					return true

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -91,8 +91,8 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if rules.IsShanghai && tx.To() == nil && len(tx.Data()) > int(opts.Config.MaxInitCodeSize()) {
 		return fmt.Errorf("%w: code size %v, limit %v", core.ErrMaxInitCodeSizeExceeded, len(tx.Data()), int(opts.Config.MaxInitCodeSize()))
 	}
-	if rules.IsOsaka && tx.Gas() > params.MaxTxGas {
-		return fmt.Errorf("%w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, params.MaxTxGas, tx.Gas())
+	if !opts.Config.IsArbitrum() && rules.IsOsaka && tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
+		return fmt.Errorf("%w (cap: %d, tx: %d)", core.ErrGasLimitTooHigh, params.MaxTxGasRenamedForNitroMerges, tx.Gas())
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur for transactions created using the RPC.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -499,8 +499,8 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 	if env.header.ExcessBlobGas != nil {
 		filter.BlobFee = uint256.MustFromBig(eip4844.CalcBlobFee(miner.chainConfig, env.header))
 	}
-	if miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
-		filter.GasLimitCap = params.MaxTxGas
+	if !miner.chainConfig.IsArbitrum() && miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
+		filter.GasLimitCap = params.MaxTxGasRenamedForNitroMerges
 	}
 	filter.OnlyPlainTxs, filter.OnlyBlobTxs = true, false
 	pendingPlainTxs := miner.txpool.Pending(filter)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -28,7 +28,7 @@ const (
 	MaxGasLimit          uint64 = 0x7fffffffffffffff // Maximum the gas limit (2^63-1).
 	GenesisGasLimit      uint64 = 4712388            // Gas limit of the Genesis block.
 
-	MaxTxGas uint64 = 1 << 24 // Maximum transaction gas limit after eip-7825 (16,777,216).
+	MaxTxGasRenamedForNitroMerges uint64 = 1 << 24 // Maximum transaction gas limit after eip-7825 (16,777,216).
 
 	MaximumExtraDataSize  uint64 = 32    // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10    // Times ceil(log256(exponent)) for the EXP instruction.


### PR DESCRIPTION
This PR skips EIP-7825 for arbitrum chains as this EIP is implemented on the nitro side for simplicity

Part of NIT-3644