### PR TITLE
Make chainConfig's IsOsaka method arbosVersion conditional

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -183,7 +183,7 @@ func Transaction(ctx *cli.Context) error {
 		if chainConfig.IsShanghai(new(big.Int), 0, 0) && tx.To() == nil && len(tx.Data()) > int(chainConfig.MaxInitCodeSize()) {
 			r.Error = errors.New("max initcode size exceeded")
 		}
-		if !chainConfig.IsArbitrum() && chainConfig.IsOsaka(new(big.Int), 0) && tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
+		if !chainConfig.IsArbitrum() && chainConfig.IsOsaka(new(big.Int), 0, 0) && tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
 			r.Error = errors.New("gas limit exceeds maximum")
 		}
 		results = append(results, r)

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -78,7 +78,8 @@ func CalcExcessBlobGas(config *params.ChainConfig, parent *types.Header, headTim
 	if excessBlobGas < targetGas {
 		return 0
 	}
-	if !config.IsOsaka(config.LondonBlock, headTimestamp) {
+	// we can use 0 here because arbitrum doesn't support Blob transactions.
+	if !config.IsOsaka(config.LondonBlock, headTimestamp, 0) {
 		// Pre-Osaka, we use the formula defined by EIP-4844.
 		return excessBlobGas - targetGas
 	}
@@ -138,7 +139,8 @@ func latestBlobConfig(cfg *params.ChainConfig, time uint64) *params.BlobConfig {
 		return s.BPO2
 	case cfg.IsBPO1(london, time) && s.BPO1 != nil:
 		return s.BPO1
-	case cfg.IsOsaka(london, time) && s.Osaka != nil:
+	// we can use 0 here because arbitrum doesn't support Blob transactions.
+	case cfg.IsOsaka(london, time, 0) && s.Osaka != nil:
 		return s.Osaka
 	// we can use 0 here because arbitrum doesn't support Blob transactions.
 	case cfg.IsPrague(london, time, 0) && s.Prague != nil:

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -51,7 +51,7 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain) *Bloc
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// check EIP 7934 RLP-encoded block size cap
 	// but skip for Arbitrum (since arbtrium does not need a block size cap)
-	if !v.config.IsArbitrum() && v.config.IsOsaka(block.Number(), block.Time()) && block.Size() > params.MaxBlockSize {
+	if !v.config.IsArbitrum() && v.config.IsOsaka(block.Number(), block.Time(), 0) && block.Size() > params.MaxBlockSize {
 		return ErrBlockOversized
 	}
 	// Check whether the block is already imported.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -497,7 +497,7 @@ func (st *stateTransition) preCheck() error {
 		}
 	}
 	// Check the blob version validity
-	isOsaka := st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber, st.evm.Context.Time)
+	isOsaka := st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber, st.evm.Context.Time, st.evm.Context.ArbOSVersion)
 	if msg.BlobHashes != nil {
 		// The to field of a blob tx type is mandatory, and a `BlobTx` transaction internally
 		// has it as a non-nillable value, so any msg derived from blob transaction has it non-nil.

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1263,12 +1263,12 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 	}
 	pool.mu.Lock()
 	if reset != nil {
-		if reset.newHead != nil && reset.oldHead != nil {
+		if !pool.chainconfig.IsArbitrum() && reset.newHead != nil && reset.oldHead != nil {
 			// Discard the transactions with the gas limit higher than the cap.
-			if pool.chainconfig.IsOsaka(reset.newHead.Number, reset.newHead.Time) && !pool.chainconfig.IsOsaka(reset.oldHead.Number, reset.oldHead.Time) {
+			if pool.chainconfig.IsOsaka(reset.newHead.Number, reset.newHead.Time, 0) && !pool.chainconfig.IsOsaka(reset.oldHead.Number, reset.oldHead.Time, 0) {
 				var hashes []common.Hash
 				pool.all.Range(func(hash common.Hash, tx *types.Transaction) bool {
-					if !pool.chainconfig.IsArbitrum() && tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
+					if tx.Gas() > params.MaxTxGasRenamedForNitroMerges {
 						hashes = append(hashes, hash)
 					}
 					return true

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -179,7 +179,7 @@ func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationO
 		return err
 	}
 	// Fork-specific sidecar checks, including proof verification.
-	if opts.Config.IsOsaka(head.Number, head.Time) {
+	if opts.Config.IsOsaka(head.Number, head.Time, types.DeserializeHeaderExtraInformation(head).ArbOSFormatVersion) {
 		return validateBlobSidecarOsaka(sidecar, hashes)
 	}
 	return validateBlobSidecarLegacy(sidecar, hashes)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -348,9 +348,10 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 }
 
 func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *transactionsByPriceAndNonce, interrupt *atomic.Int32) error {
+	arbosVersion := types.DeserializeHeaderExtraInformation(env.header).ArbOSFormatVersion
 	var (
-		isOsaka  = miner.chainConfig.IsOsaka(env.header.Number, env.header.Time)
-		isCancun = miner.chainConfig.IsCancun(env.header.Number, env.header.Time, types.DeserializeHeaderExtraInformation(env.header).ArbOSFormatVersion)
+		isOsaka  = miner.chainConfig.IsOsaka(env.header.Number, env.header.Time, arbosVersion)
+		isCancun = miner.chainConfig.IsCancun(env.header.Number, env.header.Time, arbosVersion)
 		gasLimit = env.header.GasLimit
 	)
 	if env.gasPool == nil {
@@ -499,7 +500,7 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 	if env.header.ExcessBlobGas != nil {
 		filter.BlobFee = uint256.MustFromBig(eip4844.CalcBlobFee(miner.chainConfig, env.header))
 	}
-	if !miner.chainConfig.IsArbitrum() && miner.chainConfig.IsOsaka(env.header.Number, env.header.Time) {
+	if !miner.chainConfig.IsArbitrum() && miner.chainConfig.IsOsaka(env.header.Number, env.header.Time, 0) {
 		filter.GasLimitCap = params.MaxTxGasRenamedForNitroMerges
 	}
 	filter.OnlyPlainTxs, filter.OnlyBlobTxs = true, false

--- a/params/config.go
+++ b/params/config.go
@@ -695,7 +695,10 @@ func (c *ChainConfig) IsPrague(num *big.Int, time uint64, currentArbosVersion ui
 }
 
 // IsOsaka returns whether time is either equal to the Osaka fork time or greater.
-func (c *ChainConfig) IsOsaka(num *big.Int, time uint64) bool {
+func (c *ChainConfig) IsOsaka(num *big.Int, time uint64, currentArbosVersion uint64) bool {
+	if c.IsArbitrum() {
+		return currentArbosVersion >= ArbosVersion_50
+	}
 	return c.IsLondon(num) && isTimestampForked(c.OsakaTime, time)
 }
 
@@ -1001,7 +1004,7 @@ func (c *ChainConfig) LatestFork(time uint64, currentArbosVersion uint64) forks.
 	london := c.LondonBlock
 
 	switch {
-	case c.IsOsaka(london, time):
+	case c.IsOsaka(london, time, currentArbosVersion):
 		return forks.Osaka
 	case c.IsPrague(london, time, currentArbosVersion):
 		return forks.Prague
@@ -1207,7 +1210,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 		IsShanghai:       isMerge && c.IsShanghai(num, timestamp, currentArbosVersion),
 		IsCancun:         isMerge && c.IsCancun(num, timestamp, currentArbosVersion),
 		IsPrague:         isMerge && c.IsPrague(num, timestamp, currentArbosVersion),
-		IsOsaka:          isMerge && c.IsOsaka(num, timestamp),
+		IsOsaka:          isMerge && c.IsOsaka(num, timestamp, currentArbosVersion),
 		IsVerkle:         isVerkle,
 		IsEIP4762:        isVerkle,
 	}


### PR DESCRIPTION
This PR makes it that for arbitrum chains Osaka is only switched on at arbos_50 or later.

Part of NIT-3780