### PR TITLE
Enable arbos 50 support

### DIFF
--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -44,7 +44,7 @@ const ArbosVersion_FixRedeemGas = ArbosVersion_11
 const ArbosVersion_Stylus = ArbosVersion_30
 const ArbosVersion_StylusFixes = ArbosVersion_31
 const ArbosVersion_StylusChargingFixes = ArbosVersion_32
-const MaxArbosVersionSupported = ArbosVersion_40
+const MaxArbosVersionSupported = ArbosVersion_50
 const MaxDebugArbosVersionSupported = ArbosVersion_50
 const ArbosVersion_Dia = ArbosVersion_50
 


### PR DESCRIPTION
This makes it so that, once the arbos 50 upgrade is applied on chain, the nitro node will still be happy to run it.

Pulled in by: OffchainLabs/nitro/pull/3547