### PR TITLE
Treat precompile code as empty during delegation after arbos 50

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -640,6 +640,11 @@ func (evm *EVM) resolveCode(addr common.Address) []byte {
 		return code
 	}
 	if target, ok := types.ParseDelegation(code); ok {
+		// This is a workaround for the fact that calls delegated to precompiles should always return empty code.
+		// This starts happening with Arbos version 50(due to EIP 7702)
+		if _, ok := evm.precompile(target); ok && evm.Context.ArbOSVersion >= params.ArbosVersion_50 {
+			return nil
+		}
 		// Note we only follow one level of delegation.
 		return evm.StateDB.GetCode(target)
 	}


### PR DESCRIPTION
Related to NIT-3280
Pulled in https://github.com/OffchainLabs/nitro/pull/3549

Fixes an incompatibility with EIP-7702 where Arbitrum’s precompile implementation returns non-empty code (0xFE), causing delegated calls to precompiles to hit an INVALID opcode. Updates behavior to treat precompile code as empty during delegation (per EIP-7702) after arbos 50