### PR TITLE
ethapi: Update eth_config implementation for Arbitrum chains

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -1052,6 +1052,13 @@ func (c *ChainConfig) ActiveSystemContracts(time uint64, currentArbosVersion uin
 	if fork >= forks.Cancun {
 		active["BEACON_ROOTS_ADDRESS"] = BeaconRootsAddress
 	}
+	// When Arbitrum is active, only HISTORY_STORAGE_ADDRESS is available.
+	if c.IsArbitrum() {
+		delete(active, "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS")
+		delete(active, "DEPOSIT_CONTRACT_ADDRESS")
+		delete(active, "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS")
+		delete(active, "BEACON_ROOTS_ADDRESS")
+	}
 	return active
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -1019,6 +1019,10 @@ func (c *ChainConfig) LatestFork(time uint64, currentArbosVersion uint64) forks.
 
 // BlobConfig returns the blob config associated with the provided fork.
 func (c *ChainConfig) BlobConfig(fork forks.Fork) *BlobConfig {
+	// When Arbitrum is active, the chain doesn't support blobs.
+	if c.IsArbitrum() {
+		return nil
+	}
 	switch fork {
 	case forks.Osaka:
 		return DefaultOsakaBlobConfig
@@ -1054,14 +1058,29 @@ func (c *ChainConfig) ActiveSystemContracts(time uint64, currentArbosVersion uin
 // Timestamp returns the timestamp associated with the fork or returns nil if
 // the fork isn't defined or isn't a time-based fork.
 func (c *ChainConfig) Timestamp(fork forks.Fork) *uint64 {
+	// When the active chain is Arbitrum, the activation of a fork is not
+	// time-based. So, all forks are considered to be enabled.
+	arbTime := uint64(0)
 	switch {
 	case fork == forks.Osaka:
+		if c.IsArbitrum() {
+			return &arbTime
+		}
 		return c.OsakaTime
 	case fork == forks.Prague:
+		if c.IsArbitrum() {
+			return &arbTime
+		}
 		return c.PragueTime
 	case fork == forks.Cancun:
+		if c.IsArbitrum() {
+			return &arbTime
+		}
 		return c.CancunTime
 	case fork == forks.Shanghai:
+		if c.IsArbitrum() {
+			return &arbTime
+		}
 		return c.ShanghaiTime
 	default:
 		return nil


### PR DESCRIPTION
There are a couple of important changes:
   1. Arbitrum chains don't support blob posting, so, BlobSchedule is not important.
	 2. The Timestamp method needed to be updated to handle the fact that Arbitrum performs upgrades based on block number, and not timestamp.

Part of: NIT-3679
Pulled in by: https://github.com/OffchainLabs/nitro/pull/3571