### PR TITLE
Multigas: Instrument GasChargingHook with multi-gas

### DIFF
--- a/core/vm/evm_arbitrum.go
+++ b/core/vm/evm_arbitrum.go
@@ -44,7 +44,7 @@ func (evm *EVM) JumpDests() JumpDestCache {
 
 type TxProcessingHook interface {
 	StartTxHook() (bool, multigas.MultiGas, error, []byte) // return 4-tuple rather than *struct to avoid an import cycle
-	GasChargingHook(gasRemaining *uint64) (common.Address, error)
+	GasChargingHook(gasRemaining *uint64) (common.Address, multigas.MultiGas, error)
 	PushContract(contract *Contract)
 	PopContract()
 	HeldGas() uint64
@@ -69,8 +69,8 @@ func (p DefaultTxProcessor) StartTxHook() (bool, multigas.MultiGas, error, []byt
 	return false, multigas.ZeroGas(), nil, nil
 }
 
-func (p DefaultTxProcessor) GasChargingHook(gasRemaining *uint64) (common.Address, error) {
-	return p.evm.Context.Coinbase, nil
+func (p DefaultTxProcessor) GasChargingHook(gasRemaining *uint64) (common.Address, multigas.MultiGas, error) {
+	return p.evm.Context.Coinbase, multigas.ZeroGas(), nil
 }
 
 func (p DefaultTxProcessor) PushContract(contract *Contract) {}


### PR DESCRIPTION
Part of NIT-3551

Nitro PR: https://github.com/OffchainLabs/nitro/pull/3576

- Return multigas from GasChargingHook
- Add multigas from GasChargingHook to usedMultiGas in state transition execution