### PR TITLE
Multigas: Correct the multi-gas attribution in the contract

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -50,7 +50,8 @@ type Contract struct {
 	value *uint256.Int
 
 	// Arbitrum: total used multi-dimensional gas
-	UsedMultiGas multigas.MultiGas
+	UsedMultiGas     multigas.MultiGas
+	RetainedMultiGas multigas.MultiGas
 }
 
 // NewContract returns a new contract environment for the execution of EVM.
@@ -60,12 +61,13 @@ func NewContract(caller common.Address, address common.Address, value *uint256.I
 		jumpDests = newMapJumpDests()
 	}
 	return &Contract{
-		caller:       caller,
-		address:      address,
-		jumpDests:    jumpDests,
-		Gas:          gas,
-		value:        value,
-		UsedMultiGas: multigas.ZeroGas(),
+		caller:           caller,
+		address:          address,
+		jumpDests:        jumpDests,
+		Gas:              gas,
+		value:            value,
+		UsedMultiGas:     multigas.ZeroGas(),
+		RetainedMultiGas: multigas.ZeroGas(),
 	}
 }
 

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -209,6 +209,7 @@ func makeCallVariantGasCallEIP2929(oldCalculator gasFunc, addressPosition int) g
 		// outside of this function, as part of the dynamic gas, and that will make it
 		// also become correctly reported to tracers.
 		contract.Gas += coldCost
+		contract.RetainedMultiGas.SaturatingIncrementInto(multigas.ResourceKindStorageAccess, coldCost)
 
 		// Cold slot access considered as storage access.
 		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
@@ -339,7 +340,8 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 		// adding it to the return, it will be charged outside of this function, as
 		// part of the dynamic gas. This will ensure it is correctly reported to
 		// tracers.
-		contract.Gas += multiGas.Get(multigas.ResourceKindStorageAccess)
+		contract.Gas += multiGas.SingleGas()
+		contract.RetainedMultiGas.SaturatingAddInto(multiGas)
 
 		var overflow bool
 		if multiGas, overflow = multiGas.SafeAdd(multiOld); overflow {

--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -99,10 +99,14 @@ func makeCallVariantGasEIP4762(oldCalculator gasFunc, withTransferCosts bool) ga
 			}
 		}
 
-		contract.Gas -= witnessGas.SingleGas()
 		// if the operation fails, adds witness gas to the gas before returning the error
+		contract.Gas -= witnessGas.SingleGas()
+		contract.UsedMultiGas.SaturatingAddInto(witnessGas)
 		multiGas, err := oldCalculator(evm, contract, stack, mem, memorySize)
-		contract.Gas += witnessGas.SingleGas() // restore witness gas so that it can be charged at the callsite
+
+		// restore witness gas so that it can be charged at the callsite
+		contract.Gas += witnessGas.SingleGas()
+		contract.RetainedMultiGas.SaturatingAddInto(witnessGas)
 		// Witness gas considered as storage access.
 		// See rationale in: https://github.com/OffchainLabs/nitro/blob/master/docs/decisions/0002-multi-dimensional-gas-metering.md
 		var overflow bool


### PR DESCRIPTION
Fixes NIT-3837

- Add `RetainedMultiGas` in contract
- Attribute retained multi gas in `makeCallVariantGasEIP4762 ` and  in `makeCallVariantGasCallEIP2929`
- Check the attribution in unit-test