### PR TITLE
core: Instrument WasmAccountTouchCost with multigas

### DIFF
--- a/core/vm/operations_acl_arbitrum.go
+++ b/core/vm/operations_acl_arbitrum.go
@@ -154,8 +154,8 @@ func WasmCallCost(db StateDB, contract common.Address, value *uint256.Int, budge
 func WasmAccountTouchCost(cfg *params.ChainConfig, db StateDB, addr common.Address, withCode bool) multigas.MultiGas {
 	cost := multigas.ZeroGas()
 	if withCode {
-		extCodeCost := cfg.MaxCodeSize() / 24576 * params.ExtcodeSizeGasEIP150
-		cost.SaturatingIncrementInto(multigas.ResourceKindComputation, extCodeCost)
+		extCodeCost := cfg.MaxCodeSize() / params.DefaultMaxCodeSize * params.ExtcodeSizeGasEIP150
+		cost.SaturatingIncrementInto(multigas.ResourceKindStorageAccess, extCodeCost)
 	}
 
 	if !db.AddressInAccessList(addr) {


### PR DESCRIPTION
Part of NIT-3796
Nitro PR: https://github.com/OffchainLabs/nitro/pull/3645

- Return multigas from `WasmAccountTouchCost`