### PR TITLE
Use ubuntu-4 for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,31 +10,31 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-4
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.21.4
+          go-version-file: "go.mod"
       - name: Test
         run: make test
 
   run-linter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-4
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.21.4
+          go-version-file: "go.mod"
       - name: Test
         run: make lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
   schedule:
     - cron: '30 18 * * 5'
 
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-4' }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -2,7 +2,7 @@ name: Merge Checks
 
 on:
   pull_request_target:
-    branches: [ master ]
+    branches: [master]
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-design-approved:
     name: Check if Design Approved
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-4
     steps:
       - name: Check if design approved and update status
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0


### PR DESCRIPTION
This switches the actions from the over-committed `ubuntu-latest` GitHub standard machines to OCL's own runners.

In addition, this change also upgrades the versions of the checkout and setup-go actions and switches to reading the version of go to use from the CI actions into the go.mod file, and updtes the go.mod to match upstream.