### PR TITLE
arbitrum: Add filtered transactions report types

### DIFF
--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -44,14 +44,14 @@ type FilteredAddressRecord struct {
 }
 
 type FilteredTxReport struct {
-	ID                     string                  `json:"id"`
-	TxHash                 common.Hash             `json:"txHash"`
-	TxRLP                  hexutil.Bytes           `json:"txRLP"`
-	FilteredAddresses      []FilteredAddressRecord `json:"filteredAddresses"`
-	BlockNumber            uint64                  `json:"blockNumber"`
-	ParentBlockHash        common.Hash             `json:"parentBlockHash"`
-	PositionInBlock        uint64                  `json:"positionInBlock"`
-	FilteredAt             time.Time               `json:"filteredAt"`
-	IsDelayed              bool                    `json:"isDelayed"`
-	DelayedInboxRequestId  *common.Hash            `json:"delayedInboxRequestId,omitempty"`
+	ID                    string                  `json:"id"`
+	TxHash                common.Hash             `json:"txHash"`
+	TxRLP                 hexutil.Bytes           `json:"txRLP"`
+	FilteredAddresses     []FilteredAddressRecord `json:"filteredAddresses"`
+	BlockNumber           uint64                  `json:"blockNumber"`
+	ParentBlockHash       common.Hash             `json:"parentBlockHash"`
+	PositionInBlock       uint64                  `json:"positionInBlock"`
+	FilteredAt            time.Time               `json:"filteredAt"`
+	IsDelayed             bool                    `json:"isDelayed"`
+	DelayedInboxRequestId *common.Hash            `json:"delayedInboxRequestId,omitempty"`
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -36,13 +36,11 @@ type EventRuleMatch struct {
 	RawLog            *RawLog `json:"rawLog,omitempty"`
 }
 
-// lint:require-exhaustive-initialization
 type FilterReason struct {
 	Reason FilterReasonType `json:"reason"`
 	*EventRuleMatch
 }
 
-// lint:require-exhaustive-initialization
 type FilteredAddressRecord struct {
 	Address     common.Address `json:"address"`
 	FilterSetId string         `json:"filterSetId"`

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -36,13 +36,14 @@ type EventRuleMatch struct {
 	RawLog            *RawLog `json:"rawLog,omitempty"`
 }
 
+// lint:require-exhaustive-initialization
 type FilterReason struct {
 	Reason FilterReasonType `json:"reason"`
 	*EventRuleMatch
 }
 
+// lint:require-exhaustive-initialization
 type FilteredAddressRecord struct {
-	Address     common.Address `json:"address"`
-	FilterSetID string         `json:"filterSetId"`
+	Address common.Address `json:"address"`
 	FilterReason
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -38,17 +38,20 @@ type FilterReason struct {
 }
 
 type FilteredAddressRecord struct {
-	Address common.Address `json:"address"`
+	Address     common.Address `json:"address"`
+	FilterSetId string         `json:"filterSetId"`
 	FilterReason
 }
 
 type FilteredTxReport struct {
-	TxHash            common.Hash             `json:"txHash"`
-	TxRLP             hexutil.Bytes           `json:"txRLP"`
-	FilteredAddresses []FilteredAddressRecord `json:"filteredAddresses"`
-	BlockNumber       uint64                  `json:"blockNumber"`
-	ParentBlockHash   common.Hash             `json:"parentBlockHash"`
-	PositionInBlock   uint64                  `json:"positionInBlock"`
-	FilteredAt        time.Time               `json:"filteredAt"`
-	IsDelayed         bool                    `json:"isDelayed"`
+	ID                     string                  `json:"id"`
+	TxHash                 common.Hash             `json:"txHash"`
+	TxRLP                  hexutil.Bytes           `json:"txRLP"`
+	FilteredAddresses      []FilteredAddressRecord `json:"filteredAddresses"`
+	BlockNumber            uint64                  `json:"blockNumber"`
+	ParentBlockHash        common.Hash             `json:"parentBlockHash"`
+	PositionInBlock        uint64                  `json:"positionInBlock"`
+	FilteredAt             time.Time               `json:"filteredAt"`
+	IsDelayed              bool                    `json:"isDelayed"`
+	DelayedInboxRequestId  *common.Hash            `json:"delayedInboxRequestId,omitempty"`
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -43,6 +43,6 @@ type FilterReason struct {
 
 type FilteredAddressRecord struct {
 	Address     common.Address `json:"address"`
-	FilterSetId string         `json:"filterSetId"`
+	FilterSetID string         `json:"filterSetId"`
 	FilterReason
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -1,8 +1,6 @@
 package filter
 
 import (
-	"time"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -24,34 +22,29 @@ const (
 	ReasonSelfdestructBeneficiary       FilterReasonType = "selfdestruct_beneficiary"
 )
 
+// lint:require-exhaustive-initialization
 type RawLog struct {
 	Address common.Address `json:"address"`
 	Topics  []common.Hash  `json:"topics"`
 	Data    hexutil.Bytes  `json:"data"`
 }
 
-type FilterReason struct {
-	Reason            FilterReasonType `json:"reason"`
-	MatchedEvent      string           `json:"matchedEvent,omitempty"`
-	MatchedTopicIndex int              `json:"matchedTopicIndex,omitempty"`
-	RawLog            *RawLog          `json:"rawLog,omitempty"`
+// lint:require-exhaustive-initialization
+type EventRuleMatch struct {
+	MatchedEvent      string  `json:"matchedEvent"`
+	MatchedTopicIndex int     `json:"matchedTopicIndex,omitempty"`
+	RawLog            *RawLog `json:"rawLog,omitempty"`
 }
 
+// lint:require-exhaustive-initialization
+type FilterReason struct {
+	Reason FilterReasonType `json:"reason"`
+	*EventRuleMatch
+}
+
+// lint:require-exhaustive-initialization
 type FilteredAddressRecord struct {
 	Address     common.Address `json:"address"`
 	FilterSetId string         `json:"filterSetId"`
 	FilterReason
-}
-
-type FilteredTxReport struct {
-	ID                    string                  `json:"id"`
-	TxHash                common.Hash             `json:"txHash"`
-	TxRLP                 hexutil.Bytes           `json:"txRLP"`
-	FilteredAddresses     []FilteredAddressRecord `json:"filteredAddresses"`
-	BlockNumber           uint64                  `json:"blockNumber"`
-	ParentBlockHash       common.Hash             `json:"parentBlockHash"`
-	PositionInBlock       uint64                  `json:"positionInBlock"`
-	FilteredAt            time.Time               `json:"filteredAt"`
-	IsDelayed             bool                    `json:"isDelayed"`
-	DelayedInboxRequestId *common.Hash            `json:"delayedInboxRequestId,omitempty"`
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -1,0 +1,54 @@
+package filter
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type FilterReasonType string
+
+const (
+	ReasonFrom                          FilterReasonType = "from"
+	ReasonTo                            FilterReasonType = "to"
+	ReasonDealiasedFrom                 FilterReasonType = "dealiased_from"
+	ReasonRetryableBeneficiary          FilterReasonType = "retryable_beneficiary"
+	ReasonRetryableFeeRefund            FilterReasonType = "retryable_fee_refund"
+	ReasonRetryableTo                   FilterReasonType = "retryable_to"
+	ReasonDealiasedRetryableBeneficiary FilterReasonType = "dealiased_retryable_beneficiary"
+	ReasonDealiasedRetryableFeeRefund   FilterReasonType = "dealiased_retryable_fee_refund"
+	ReasonEventRule                     FilterReasonType = "event_rule"
+	ReasonContractAddress               FilterReasonType = "contract_address"
+	ReasonContractCaller                FilterReasonType = "contract_caller"
+	ReasonSelfdestructBeneficiary       FilterReasonType = "selfdestruct_beneficiary"
+)
+
+type RawLog struct {
+	Address common.Address `json:"address"`
+	Topics  []common.Hash  `json:"topics"`
+	Data    hexutil.Bytes  `json:"data"`
+}
+
+type FilterReason struct {
+	Reason            FilterReasonType `json:"reason"`
+	MatchedEvent      string           `json:"matchedEvent,omitempty"`
+	MatchedTopicIndex int              `json:"matchedTopicIndex,omitempty"`
+	RawLog            *RawLog          `json:"rawLog,omitempty"`
+}
+
+type FilteredAddressRecord struct {
+	Address common.Address `json:"address"`
+	FilterReason
+}
+
+type FilteredTxReport struct {
+	TxHash            common.Hash             `json:"txHash"`
+	TxRLP             hexutil.Bytes           `json:"txRLP"`
+	FilteredAddresses []FilteredAddressRecord `json:"filteredAddresses"`
+	BlockNumber       uint64                  `json:"blockNumber"`
+	ParentBlockHash   common.Hash             `json:"parentBlockHash"`
+	PositionInBlock   uint64                  `json:"positionInBlock"`
+	FilteredAt        time.Time               `json:"filteredAt"`
+	IsDelayed         bool                    `json:"isDelayed"`
+}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
@@ -221,17 +222,17 @@ func (s *StateDB) SetAddressChecker(checker AddressChecker) {
 	s.arbExtraData.addressChecker = checker
 }
 
-func (s *StateDB) TouchAddress(addr common.Address) {
+func (s *StateDB) TouchAddress(record filter.FilteredAddressRecord) {
 	if s.arbExtraData.addressCheckerState != nil {
-		s.arbExtraData.addressCheckerState.TouchAddress(addr)
+		s.arbExtraData.addressCheckerState.TouchAddress(record)
 	}
 }
 
-func (s *StateDB) IsAddressFiltered() bool {
+func (s *StateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 	if s.arbExtraData.addressCheckerState != nil {
 		return s.arbExtraData.addressCheckerState.IsFiltered()
 	}
-	return false
+	return false, nil
 }
 
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -222,7 +222,7 @@ func (s *StateDB) SetAddressChecker(checker AddressChecker) {
 	s.arbExtraData.addressChecker = checker
 }
 
-func (s *StateDB) TouchAddress(record filter.FilteredAddressRecord) {
+func (s *StateDB) TouchAddress(record *filter.FilteredAddressRecord) {
 	if s.arbExtraData.addressCheckerState != nil {
 		s.arbExtraData.addressCheckerState.TouchAddress(record)
 	}

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -313,7 +313,7 @@ var ErrArbTxFilter error = errors.New("internal error")
 // Implementations manage their own synchronization (sync, WaitGroup, channels, etc).
 type AddressCheckerState interface {
 	// TouchAddress records an address access and checks if it should be filtered.
-	TouchAddress(record filter.FilteredAddressRecord)
+	TouchAddress(record *filter.FilteredAddressRecord)
 
 	// IsFiltered returns whether any touched address was filtered and the
 	// list of filtered address records collected during the transaction.

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"slices"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -312,11 +313,12 @@ var ErrArbTxFilter error = errors.New("internal error")
 // Implementations manage their own synchronization (sync, WaitGroup, channels, etc).
 type AddressCheckerState interface {
 	// TouchAddress records an address access and checks if it should be filtered.
-	TouchAddress(addr common.Address)
+	TouchAddress(record filter.FilteredAddressRecord)
 
-	// IsFiltered returns whether any touched address was filtered.
+	// IsFiltered returns whether any touched address was filtered and the
+	// list of filtered address records collected during the transaction.
 	// Blocks until all pending checks complete (implementation-specific).
-	IsFiltered() bool
+	IsFiltered() (bool, []filter.FilteredAddressRecord)
 }
 
 // AddressChecker creates per-tx state instances for address filtering.

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -19,6 +19,7 @@ package state
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -365,11 +366,11 @@ func (s *hookedStateDB) SetAddressChecker(checker AddressChecker) {
 	s.inner.SetAddressChecker(checker)
 }
 
-func (s *hookedStateDB) TouchAddress(addr common.Address) {
-	s.inner.TouchAddress(addr)
+func (s *hookedStateDB) TouchAddress(record filter.FilteredAddressRecord) {
+	s.inner.TouchAddress(record)
 }
 
-func (s *hookedStateDB) IsAddressFiltered() bool {
+func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 	return s.inner.IsAddressFiltered()
 }
 

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -366,7 +366,7 @@ func (s *hookedStateDB) SetAddressChecker(checker AddressChecker) {
 	s.inner.SetAddressChecker(checker)
 }
 
-func (s *hookedStateDB) TouchAddress(record filter.FilteredAddressRecord) {
+func (s *hookedStateDB) TouchAddress(record *filter.FilteredAddressRecord) {
 	s.inner.TouchAddress(record)
 }
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -924,7 +924,7 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(filter.FilteredAddressRecord{
+	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
 		Address:      beneficiary.Bytes20(),
 		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary},
 	})
@@ -958,7 +958,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	}
 
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(filter.FilteredAddressRecord{
+	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
 		Address:      beneficiary.Bytes20(),
 		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary},
 	})

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/arbitrum/multigas"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -923,7 +924,10 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(beneficiary.Bytes20())
+	evm.StateDB.TouchAddress(filter.FilteredAddressRecord{
+		Address:      beneficiary.Bytes20(),
+		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary},
+	})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
 	evm.StateDB.SelfDestruct(scope.Contract.Address())
@@ -954,7 +958,10 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	}
 
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(beneficiary.Bytes20())
+	evm.StateDB.TouchAddress(filter.FilteredAddressRecord{
+		Address:      beneficiary.Bytes20(),
+		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary},
+	})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.SubBalance(scope.Contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -926,7 +926,7 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	beneficiary := scope.Stack.pop()
 	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
 		Address:      beneficiary.Bytes20(),
-		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary},
+		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil},
 	})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
@@ -960,7 +960,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	beneficiary := scope.Stack.pop()
 	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
 		Address:      beneficiary.Bytes20(),
-		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary},
+		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil},
 	})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.SubBalance(scope.Contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -55,8 +56,8 @@ type StateDB interface {
 	ClearTxFilter()
 	IsTxFiltered() bool
 	SetAddressChecker(checker state.AddressChecker)
-	TouchAddress(addr common.Address)
-	IsAddressFiltered() bool
+	TouchAddress(record filter.FilteredAddressRecord)
+	IsAddressFiltered() (bool, []filter.FilteredAddressRecord)
 
 	Recording() bool
 	Deterministic() bool

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -56,7 +56,7 @@ type StateDB interface {
 	ClearTxFilter()
 	IsTxFiltered() bool
 	SetAddressChecker(checker state.AddressChecker)
-	TouchAddress(record filter.FilteredAddressRecord)
+	TouchAddress(record *filter.FilteredAddressRecord)
 	IsAddressFiltered() (bool, []filter.FilteredAddressRecord)
 
 	Recording() bool

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -286,9 +286,9 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	if txFilterer != nil {
 		txFilterer.Setup(dirtyState)
 
-		dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom}})
+		dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
 		if call.To != nil {
-			dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo}})
+			dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
 		}
 	}
 

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -285,9 +286,9 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	if txFilterer != nil {
 		txFilterer.Setup(dirtyState)
 
-		dirtyState.TouchAddress(call.From)
+		dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom}})
 		if call.To != nil {
-			dirtyState.TouchAddress(*call.To)
+			dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo}})
 		}
 	}
 


### PR DESCRIPTION
Part of NIT-4642
Pulled in by https://github.com/OffchainLabs/nitro/pull/4557

- [x] TouchAddress accepts FilteredAddressRecord (address + reason) instead of common.Address. 
- [x] IsFiltered returns (bool, []FilteredAddressRecord) to propagate which addresses were filtered and why. 
- [x] Adds arbitrum/filter package with report types (FilterReasonType, FilteredAddressRecord).                