### PR TITLE
multigas: use unchecked add to improve performance

### DIFF
--- a/arbitrum/multigas/resources.go
+++ b/arbitrum/multigas/resources.go
@@ -204,7 +204,7 @@ func (z *MultiGas) SaturatingAddInto(x MultiGas) {
 // UncheckedAddInto adds x into z in-place without checking for overflow. This function can be used to
 // improve performance in places we know there won't be an overflow. For instance, when
 // go-ethereum's upstream code also doesn't check for overflows.
-func (z *MultiGas) UncheckedAddInto(x MultiGas) {
+func (z *MultiGas) UncheckedAddInto(x *MultiGas) {
 	for i := range int(NumResourceKind) {
 		z.gas[i] = z.gas[i] + x.gas[i]
 	}

--- a/arbitrum/multigas/resources.go
+++ b/arbitrum/multigas/resources.go
@@ -219,13 +219,13 @@ func (z MultiGas) SafeSub(x MultiGas) (MultiGas, bool) {
 	res, underflow := z, false
 
 	for i := 0; i < int(NumResourceKind); i++ {
-		res.gas[i], underflow = saturatingScalarSub(res.gas[i], x.gas[i])
+		res.gas[i], underflow = safeScalarSub(res.gas[i], x.gas[i])
 		if underflow {
 			return z, true
 		}
 	}
 
-	res.refund, underflow = saturatingScalarSub(res.refund, x.refund)
+	res.refund, underflow = safeScalarSub(res.refund, x.refund)
 	if underflow {
 		return z, true
 	}
@@ -241,9 +241,9 @@ func (z MultiGas) SafeSub(x MultiGas) (MultiGas, bool) {
 func (z MultiGas) SaturatingSub(x MultiGas) MultiGas {
 	res := z
 	for i := 0; i < int(NumResourceKind); i++ {
-		res.gas[i], _ = saturatingScalarSub(res.gas[i], x.gas[i])
+		res.gas[i] = saturatingScalarSub(res.gas[i], x.gas[i])
 	}
-	res.refund, _ = saturatingScalarSub(res.refund, x.refund)
+	res.refund = saturatingScalarSub(res.refund, x.refund)
 	res.recomputeTotal()
 	return res
 }
@@ -271,8 +271,8 @@ func (z MultiGas) SafeIncrement(kind ResourceKind, gas uint64) (MultiGas, bool) 
 // and the total incremented by gas. On overflow, the field(s) are clamped to MaxUint64.
 func (z MultiGas) SaturatingIncrement(kind ResourceKind, gas uint64) MultiGas {
 	res := z
-	res.gas[kind], _ = safeScalarAdd(z.gas[kind], gas)
-	res.total, _ = safeScalarAdd(z.total, gas)
+	res.gas[kind] = saturatingScalarAdd(z.gas[kind], gas)
+	res.total = saturatingScalarAdd(z.total, gas)
 	return res
 }
 
@@ -467,13 +467,22 @@ func saturatingScalarAdd(a, b uint64) uint64 {
 	return sum
 }
 
-// saturatingScalarSub subtracts two uint64 values, returning the difference and a boolean
-// indicating whether an underflow occurred. If an underflow occurs, the difference is
-// set to 0.
-func saturatingScalarSub(a, b uint64) (uint64, bool) {
+// safeScalarSub subtracts two uint64 values, returning the difference and a boolean indicating
+// whether an underflow occurred. If an underflow occurs, the difference is set to 0.
+func safeScalarSub(a, b uint64) (uint64, bool) {
 	diff, borrow := bits.Sub64(a, b, 0)
 	if borrow != 0 {
 		return 0, true
 	}
 	return diff, false
+}
+
+// saturatingScalarSub subtracts two uint64 values returning the difference. If an underflow occurs,
+// the difference is set to 0.
+func saturatingScalarSub(a, b uint64) uint64 {
+	diff, borrow := bits.Sub64(a, b, 0)
+	if borrow != 0 {
+		return 0
+	}
+	return diff
 }

--- a/arbitrum/multigas/resources.go
+++ b/arbitrum/multigas/resources.go
@@ -203,6 +203,17 @@ func (z *MultiGas) SaturatingAddInto(x MultiGas) {
 	z.refund, _ = saturatingScalarAdd(z.refund, x.refund)
 }
 
+// UncheckedAddInto adds x into z in-place without checking for overflow. This function can be used to
+// improve performance in places we know there won't be an overflow. For instance, when
+// go-ethereum's upstream code also doesn't check for overflows.
+func (z *MultiGas) UncheckedAddInto(x MultiGas) {
+	for i := range int(NumResourceKind) {
+		z.gas[i] = z.gas[i] + x.gas[i]
+	}
+	z.total = z.total + x.total
+	z.refund = z.refund + x.refund
+}
+
 // SafeSub returns a copy of z with the per-kind, total, and refund gas
 // subtracted by the values from x. It returns the updated value and true if
 // a underflow occurred.
@@ -298,6 +309,14 @@ func (z MultiGas) SaturatingDecrement(kind ResourceKind, gas uint64) MultiGas {
 func (z *MultiGas) SaturatingIncrementInto(kind ResourceKind, gas uint64) {
 	z.gas[kind], _ = saturatingScalarAdd(z.gas[kind], gas)
 	z.total, _ = saturatingScalarAdd(z.total, gas)
+}
+
+// UncheckedIncrementInto increments the given resource kind and total in-place without checking for
+// overflow. This function can be used to improve performance in places we know there won't be an
+// overflow. For instance, when go-ethereum's upstream code also doesn't check for overflows.
+func (z *MultiGas) UncheckedIncrementInto(kind ResourceKind, gas uint64) {
+	z.gas[kind] = z.gas[kind] + gas
+	z.total = z.total + gas
 }
 
 // SingleGas returns the single-dimensional total gas.

--- a/arbitrum/multigas/resources.go
+++ b/arbitrum/multigas/resources.go
@@ -168,10 +168,8 @@ func (z MultiGas) SafeAdd(x MultiGas) (MultiGas, bool) {
 	}
 
 	for i := 0; i < int(NumResourceKind); i++ {
-		res.gas[i], overflow = safeScalarAdd(res.gas[i], x.gas[i])
-		if overflow {
-			return z, true
-		}
+		// If the total didn't overflow, it is impossible for a single dimension to overflow
+		res.gas[i] = res.gas[i] + x.gas[i]
 	}
 
 	return res, false

--- a/arbitrum/multigas/resources.go
+++ b/arbitrum/multigas/resources.go
@@ -131,7 +131,7 @@ func (z MultiGas) Get(kind ResourceKind) uint64 {
 func (z MultiGas) With(kind ResourceKind, amount uint64) (MultiGas, bool) {
 	res, overflow := z, false
 
-	res.total, overflow = saturatingScalarAdd(z.total-z.gas[kind], amount)
+	res.total, overflow = safeScalarAdd(z.total-z.gas[kind], amount)
 	if overflow {
 		return z, true
 	}
@@ -158,20 +158,20 @@ func (z MultiGas) WithRefund(amount uint64) MultiGas {
 func (z MultiGas) SafeAdd(x MultiGas) (MultiGas, bool) {
 	res, overflow := z, false
 
+	res.total, overflow = safeScalarAdd(res.total, x.total)
+	if overflow {
+		return z, true
+	}
+	res.refund, overflow = safeScalarAdd(res.refund, x.refund)
+	if overflow {
+		return z, true
+	}
+
 	for i := 0; i < int(NumResourceKind); i++ {
-		res.gas[i], overflow = saturatingScalarAdd(res.gas[i], x.gas[i])
+		res.gas[i], overflow = safeScalarAdd(res.gas[i], x.gas[i])
 		if overflow {
 			return z, true
 		}
-	}
-
-	res.total, overflow = saturatingScalarAdd(res.total, x.total)
-	if overflow {
-		return z, true
-	}
-	res.refund, overflow = saturatingScalarAdd(res.refund, x.refund)
-	if overflow {
-		return z, true
 	}
 
 	return res, false
@@ -184,11 +184,11 @@ func (z MultiGas) SaturatingAdd(x MultiGas) MultiGas {
 	res := z
 
 	for i := 0; i < int(NumResourceKind); i++ {
-		res.gas[i], _ = saturatingScalarAdd(res.gas[i], x.gas[i])
+		res.gas[i] = saturatingScalarAdd(res.gas[i], x.gas[i])
 	}
 
-	res.total, _ = saturatingScalarAdd(res.total, x.total)
-	res.refund, _ = saturatingScalarAdd(res.refund, x.refund)
+	res.total = saturatingScalarAdd(res.total, x.total)
+	res.refund = saturatingScalarAdd(res.refund, x.refund)
 	return res
 }
 
@@ -197,10 +197,10 @@ func (z MultiGas) SaturatingAdd(x MultiGas) MultiGas {
 // This is a hot-path helper; the public immutable API remains preferred elsewhere.
 func (z *MultiGas) SaturatingAddInto(x MultiGas) {
 	for i := 0; i < int(NumResourceKind); i++ {
-		z.gas[i], _ = saturatingScalarAdd(z.gas[i], x.gas[i])
+		z.gas[i] = saturatingScalarAdd(z.gas[i], x.gas[i])
 	}
-	z.total, _ = saturatingScalarAdd(z.total, x.total)
-	z.refund, _ = saturatingScalarAdd(z.refund, x.refund)
+	z.total = saturatingScalarAdd(z.total, x.total)
+	z.refund = saturatingScalarAdd(z.refund, x.refund)
 }
 
 // UncheckedAddInto adds x into z in-place without checking for overflow. This function can be used to
@@ -256,12 +256,12 @@ func (z MultiGas) SaturatingSub(x MultiGas) MultiGas {
 func (z MultiGas) SafeIncrement(kind ResourceKind, gas uint64) (MultiGas, bool) {
 	res, overflow := z, false
 
-	res.gas[kind], overflow = saturatingScalarAdd(z.gas[kind], gas)
+	res.gas[kind], overflow = safeScalarAdd(z.gas[kind], gas)
 	if overflow {
 		return z, true
 	}
 
-	res.total, overflow = saturatingScalarAdd(z.total, gas)
+	res.total, overflow = safeScalarAdd(z.total, gas)
 	if overflow {
 		return z, true
 	}
@@ -273,8 +273,8 @@ func (z MultiGas) SafeIncrement(kind ResourceKind, gas uint64) (MultiGas, bool) 
 // and the total incremented by gas. On overflow, the field(s) are clamped to MaxUint64.
 func (z MultiGas) SaturatingIncrement(kind ResourceKind, gas uint64) MultiGas {
 	res := z
-	res.gas[kind], _ = saturatingScalarAdd(z.gas[kind], gas)
-	res.total, _ = saturatingScalarAdd(z.total, gas)
+	res.gas[kind], _ = safeScalarAdd(z.gas[kind], gas)
+	res.total, _ = safeScalarAdd(z.total, gas)
 	return res
 }
 
@@ -307,8 +307,8 @@ func (z MultiGas) SaturatingDecrement(kind ResourceKind, gas uint64) MultiGas {
 // Unlike SaturatingIncrement, this method mutates the receiver directly and
 // is intended for VM hot paths where avoiding value copies is critical.
 func (z *MultiGas) SaturatingIncrementInto(kind ResourceKind, gas uint64) {
-	z.gas[kind], _ = saturatingScalarAdd(z.gas[kind], gas)
-	z.total, _ = saturatingScalarAdd(z.total, gas)
+	z.gas[kind] = saturatingScalarAdd(z.gas[kind], gas)
+	z.total = saturatingScalarAdd(z.total, gas)
 }
 
 // UncheckedIncrementInto increments the given resource kind and total in-place without checking for
@@ -441,7 +441,7 @@ func (z *MultiGas) DecodeRLP(s *rlp.Stream) error {
 func (z *MultiGas) recomputeTotal() (overflow bool) {
 	z.total = 0
 	for i := 0; i < int(NumResourceKind); i++ {
-		z.total, overflow = saturatingScalarAdd(z.total, z.gas[i])
+		z.total, overflow = safeScalarAdd(z.total, z.gas[i])
 		if overflow {
 			return
 		}
@@ -449,15 +449,24 @@ func (z *MultiGas) recomputeTotal() (overflow bool) {
 	return
 }
 
-// saturatingScalarAdd adds two uint64 values, returning the sum and a boolean
-// indicating whether an overflow occurred. If an overflow occurs, the sum is
-// set to math.MaxUint64.
-func saturatingScalarAdd(a, b uint64) (uint64, bool) {
+// safeScalarAdd adds two uint64 values, returning the sum and a boolean indicating whether an
+// overflow occurred. If an overflow occurs, the sum is set to math.MaxUint64.
+func safeScalarAdd(a, b uint64) (uint64, bool) {
 	sum, carry := bits.Add64(a, b, 0)
 	if carry != 0 {
 		return math.MaxUint64, true
 	}
 	return sum, false
+}
+
+// saturatingScalarAdd adds two uint64 values, returning the sum. If an overflow occurs, the sum is
+// set to math.MaxUint64.
+func saturatingScalarAdd(a, b uint64) uint64 {
+	sum, carry := bits.Add64(a, b, 0)
+	if carry != 0 {
+		return math.MaxUint64
+	}
+	return sum
 }
 
 // saturatingScalarSub subtracts two uint64 values, returning the difference and a boolean

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
@@ -200,40 +199,4 @@ func (c *Contract) GetTotalUsedMultiGas() multigas.MultiGas {
 		return c.UsedMultiGas.SaturatingSub(c.RetainedMultiGas)
 	}
 	return total
-}
-
-// AddConstantMultiGas decreases the gas used and adds to usedMultiGas the constant multi-gas cost of an opcode.
-// Returns error if out of gas.
-func (c *Contract) AddConstantMultiGas(cost uint64, op OpCode) error {
-	if c.Gas < cost {
-		return ErrOutOfGas
-	}
-	c.Gas -= cost
-
-	// SELFDESTRUCT is a special case because it charges for storage access but it isn't
-	// dependent on any input data. We charge a small computational cost for warm access like
-	// other multi-dimensional gas opcodes, and the rest is storage access to delete the
-	// contract from the database.
-	// Note we only need to cover EIP150 because it the current cost, and SELFDESTRUCT cost was
-	// zero previously.
-	if op == SELFDESTRUCT && cost == params.SelfdestructGasEIP150 {
-		// It is safe to call UncheckedIncrementInto because because we checked single gas.
-		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
-		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
-	} else {
-		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, cost)
-	}
-	return nil
-}
-
-// AddDynamicMultiGas decreases the gas used and increases the multi gas. Returns error if out of gas.
-func (c *Contract) AddDynamicMultiGas(dynamicCost *multigas.MultiGas) error {
-	singleGas := dynamicCost.SingleGas()
-	if c.Gas < singleGas {
-		return ErrOutOfGas
-	}
-	c.Gas -= singleGas
-	// It is safe to call UncheckedAddInto because because we checked single gas.
-	c.UsedMultiGas.UncheckedAddInto(dynamicCost)
-	return nil
 }

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
@@ -199,4 +200,40 @@ func (c *Contract) GetTotalUsedMultiGas() multigas.MultiGas {
 		return c.UsedMultiGas.SaturatingSub(c.RetainedMultiGas)
 	}
 	return total
+}
+
+// AddConstantMultiGas decreases the gas used and adds to usedMultiGas the constant multi-gas cost of an opcode.
+// Returns error if out of gas.
+func (c *Contract) AddConstantMultiGas(cost uint64, op OpCode) error {
+	if c.Gas < cost {
+		return ErrOutOfGas
+	}
+	c.Gas -= cost
+
+	// SELFDESTRUCT is a special case because it charges for storage access but it isn't
+	// dependent on any input data. We charge a small computational cost for warm access like
+	// other multi-dimensional gas opcodes, and the rest is storage access to delete the
+	// contract from the database.
+	// Note we only need to cover EIP150 because it the current cost, and SELFDESTRUCT cost was
+	// zero previously.
+	if op == SELFDESTRUCT && cost == params.SelfdestructGasEIP150 {
+		// It is safe to call UncheckedIncrementInto because because we checked single gas.
+		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
+		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
+	} else {
+		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, cost)
+	}
+	return nil
+}
+
+// AddDynamicMultiGas decreases the gas used and increases the multi gas. Returns error if out of gas.
+func (c *Contract) AddDynamicMultiGas(dynamicCost *multigas.MultiGas) error {
+	singleGas := dynamicCost.SingleGas()
+	if c.Gas < singleGas {
+		return ErrOutOfGas
+	}
+	c.Gas -= singleGas
+	// It is safe to call UncheckedAddInto because because we checked single gas.
+	c.UsedMultiGas.UncheckedAddInto(dynamicCost)
+	return nil
 }

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -64,9 +64,9 @@ func addConstantMultiGas(usedMultiGas *multigas.MultiGas, cost uint64, op OpCode
 	// Note we only need to cover EIP150 because it the current cost, and SELFDESTRUCT cost was
 	// zero previously.
 	if op == SELFDESTRUCT && cost == params.SelfdestructGasEIP150 {
-		usedMultiGas.SaturatingIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
-		usedMultiGas.SaturatingIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
+		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
+		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
 	} else {
-		usedMultiGas.SaturatingIncrementInto(multigas.ResourceKindComputation, cost)
+		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, cost)
 	}
 }

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -64,6 +64,10 @@ func addConstantMultiGas(usedMultiGas *multigas.MultiGas, cost uint64, op OpCode
 	// Note we only need to cover EIP150 because it the current cost, and SELFDESTRUCT cost was
 	// zero previously.
 	if op == SELFDESTRUCT && cost == params.SelfdestructGasEIP150 {
+		// To improve performance, we call UncheckedIncrementInto instead of
+		// SaturatingIncrementInto. We know this is safe because addConstantMultiGas is only
+		// called inside EVM.Run(). At that point, we know that multi-gas won't overflow
+		// because the function would end with out-of-gas first.
 		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
 		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
 	} else {

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -17,8 +17,6 @@
 package vm
 
 import (
-	"github.com/ethereum/go-ethereum/arbitrum/multigas"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
@@ -53,24 +51,4 @@ func callGas(isEip150 bool, availableGas, base uint64, callCost *uint256.Int) (u
 	}
 
 	return callCost.Uint64(), nil
-}
-
-// addConstantMultiGas adds to usedMultiGas the constant multi-gas cost of an opcode.
-func addConstantMultiGas(usedMultiGas *multigas.MultiGas, cost uint64, op OpCode) {
-	// SELFDESTRUCT is a special case because it charges for storage access but it isn't
-	// dependent on any input data. We charge a small computational cost for warm access like
-	// other multi-dimensional gas opcodes, and the rest is storage access to delete the
-	// contract from the database.
-	// Note we only need to cover EIP150 because it the current cost, and SELFDESTRUCT cost was
-	// zero previously.
-	if op == SELFDESTRUCT && cost == params.SelfdestructGasEIP150 {
-		// To improve performance, we call UncheckedIncrementInto instead of
-		// SaturatingIncrementInto. We know this is safe because addConstantMultiGas is only
-		// called inside EVM.Run(). At that point, we know that multi-gas won't overflow
-		// because the function would end with out-of-gas first.
-		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
-		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
-	} else {
-		usedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, cost)
-	}
 }

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -17,6 +17,8 @@
 package vm
 
 import (
+	"github.com/ethereum/go-ethereum/arbitrum/multigas"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
@@ -51,4 +53,39 @@ func callGas(isEip150 bool, availableGas, base uint64, callCost *uint256.Int) (u
 	}
 
 	return callCost.Uint64(), nil
+}
+
+// addConstantMultiGas decreases the gas used and adds to usedMultiGas the constant multi-gas cost of an opcode.
+// Returns error if out of gas.
+func addConstantMultiGas(c *Contract, cost uint64, op OpCode) error {
+	if c.Gas < cost {
+		return ErrOutOfGas
+	}
+	c.Gas -= cost
+
+	// SELFDESTRUCT is a special case because it charges for storage access but it isn't
+	// dependent on any input data. We charge a small computational cost for warm access like
+	// other multi-dimensional gas opcodes, and the rest is storage access to delete the
+	// contract from the database.
+	// Note we only need to cover EIP150 because it the current cost, and SELFDESTRUCT cost was
+	// zero previously.
+	if op == SELFDESTRUCT && cost == params.SelfdestructGasEIP150 {
+		// It is safe to call UncheckedIncrementInto because because we checked single gas.
+		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, params.WarmStorageReadCostEIP2929)
+		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindStorageAccessWrite, cost-params.WarmStorageReadCostEIP2929)
+	} else {
+		c.UsedMultiGas.UncheckedIncrementInto(multigas.ResourceKindComputation, cost)
+	}
+	return nil
+}
+
+// addDynamicMultiGas decreases the gas used and increases the multi gas. Returns error if out of gas.
+func addDynamicMultiGas(c *Contract, dynamicCost uint64, multigasDynamicCost *multigas.MultiGas) error {
+	if c.Gas < dynamicCost {
+		return ErrOutOfGas
+	}
+	c.Gas -= dynamicCost
+	// It is safe to call UncheckedAddInto because because we checked single gas.
+	c.UsedMultiGas.UncheckedAddInto(multigasDynamicCost)
+	return nil
 }

--- a/core/vm/gas_test.go
+++ b/core/vm/gas_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"math"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/arbitrum/multigas"
@@ -36,9 +37,9 @@ func TestConstantMultiGas(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := multigas.ZeroGas()
-			if addConstantMultiGas(&got, tc.cost, tc.op); got != tc.want {
-				t.Errorf("wrong constant multigas: got %v, want %v", got, tc.want)
+			contract := &Contract{Gas: math.MaxUint64}
+			if contract.AddConstantMultiGas(tc.cost, tc.op); contract.UsedMultiGas != tc.want {
+				t.Errorf("wrong constant multigas: got %v, want %v", contract.UsedMultiGas, tc.want)
 			}
 		})
 	}

--- a/core/vm/gas_test.go
+++ b/core/vm/gas_test.go
@@ -38,7 +38,7 @@ func TestConstantMultiGas(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			contract := &Contract{Gas: math.MaxUint64}
-			if contract.AddConstantMultiGas(tc.cost, tc.op); contract.UsedMultiGas != tc.want {
+			if addConstantMultiGas(contract, tc.cost, tc.op); contract.UsedMultiGas != tc.want {
 				t.Errorf("wrong constant multigas: got %v, want %v", contract.UsedMultiGas, tc.want)
 			}
 		})

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -246,7 +246,7 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			} else {
 				contract.Gas -= dynamicCost
 			}
-			contract.UsedMultiGas.SaturatingAddInto(multigasDynamicCost)
+			contract.UsedMultiGas.UncheckedAddInto(multigasDynamicCost)
 		}
 
 		// Do tracing before potential memory expansion

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -207,7 +207,7 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
 		}
 		// for tracing: this gas consumption event is emitted below in the debug section.
-		if err := contract.AddConstantMultiGas(cost, op); err != nil {
+		if err := addConstantMultiGas(contract, cost, op); err != nil {
 			return nil, err
 		}
 
@@ -238,7 +238,7 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
 			}
 			// for tracing: this gas consumption event is emitted below in the debug section.
-			if err := contract.AddDynamicMultiGas(&multigasDynamicCost); err != nil {
+			if err := addDynamicMultiGas(contract, dynamicCost, &multigasDynamicCost); err != nil {
 				return nil, err
 			}
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -207,12 +207,9 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
 		}
 		// for tracing: this gas consumption event is emitted below in the debug section.
-		if contract.Gas < cost {
-			return nil, ErrOutOfGas
-		} else {
-			contract.Gas -= cost
+		if err := contract.AddConstantMultiGas(cost, op); err != nil {
+			return nil, err
 		}
-		addConstantMultiGas(&contract.UsedMultiGas, cost, op)
 
 		// All ops with a dynamic memory usage also has a dynamic gas cost.
 		var memorySize uint64
@@ -241,15 +238,9 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
 			}
 			// for tracing: this gas consumption event is emitted below in the debug section.
-			if contract.Gas < dynamicCost {
-				return nil, ErrOutOfGas
-			} else {
-				contract.Gas -= dynamicCost
+			if err := contract.AddDynamicMultiGas(&multigasDynamicCost); err != nil {
+				return nil, err
 			}
-			// To improve performance, we call UncheckedAddInto instead of
-			// SaturatingAddInto. We know this is safe because multi-gas won't overflow
-			// before the function ends with out-of-gas.
-			contract.UsedMultiGas.UncheckedAddInto(multigasDynamicCost)
 		}
 
 		// Do tracing before potential memory expansion

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -246,6 +246,9 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			} else {
 				contract.Gas -= dynamicCost
 			}
+			// To improve performance, we call UncheckedAddInto instead of
+			// SaturatingAddInto. We know this is safe because multi-gas won't overflow
+			// before the function ends with out-of-gas.
 			contract.UsedMultiGas.UncheckedAddInto(multigasDynamicCost)
 		}
 


### PR DESCRIPTION
Replacing safe/saturating adds with unchecked ones can improve performance by up to ~19% in synthetic benchmarks. We can safely replace checked adds when we know that there isn't a chance of overflow. For instance, in the EVM.run() function, a uint64 gas value won't overflow because the program would run out of gas first.

Here are some benchmark results of programs that

* Without optmization:

```
$ go test -bench=BenchmarkSimpleLoop -benchtime=300x ./core/vm/runtime/
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
cpu: AMD Ryzen 9 7900 12-Core Processor
BenchmarkSimpleLoop/staticcall-identity-100M-24                      300         351708000 ns/op        224673426 B/op   6164445 allocs/op
BenchmarkSimpleLoop/call-identity-100M-24                            300         423641326 ns/op        241626949 B/op   6711476 allocs/op
BenchmarkSimpleLoop/loop-100M-24                                     300         205678035 ns/op            3858 B/op         42 allocs/op
BenchmarkSimpleLoop/loop2-100M-24                                    300         220230885 ns/op            3859 B/op         42 allocs/op
BenchmarkSimpleLoop/call-nonexist-100M-24                            300         608773800 ns/op        149273581 B/op   3731316 allocs/op
BenchmarkSimpleLoop/call-EOA-100M-24                                 300         412351029 ns/op        95533857 B/op    2985050 allocs/op
BenchmarkSimpleLoop/call-reverting-100M-24                           300         622313948 ns/op        412718387 B/op   5715753 allocs/op
PASS
```

* With optmization:

```
$ go test -bench=BenchmarkSimpleLoop -benchtime=300x ./core/vm/runtime/
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
cpu: AMD Ryzen 9 7900 12-Core Processor
BenchmarkSimpleLoop/staticcall-identity-100M-24                      300         337222851 ns/op        224673593 B/op   6164445 allocs/op
BenchmarkSimpleLoop/call-identity-100M-24                            300         403063559 ns/op        241626933 B/op   6711476 allocs/op
BenchmarkSimpleLoop/loop-100M-24                                     300         183246194 ns/op            3859 B/op         42 allocs/op
BenchmarkSimpleLoop/loop2-100M-24                                    300         203989420 ns/op            3858 B/op         42 allocs/op
BenchmarkSimpleLoop/call-nonexist-100M-24                            300         521509487 ns/op        149273509 B/op   3731316 allocs/op
BenchmarkSimpleLoop/call-EOA-100M-24                                 300         333846242 ns/op        95533859 B/op    2985050 allocs/op
BenchmarkSimpleLoop/call-reverting-100M-24                           300         593545585 ns/op        412723111 B/op   5715769 allocs/op
PASS
```

Pulled in by https://github.com/OffchainLabs/nitro/pull/4585