### PR TITLE
params: Add DisableOffchainArbOwner chain config parameter

### DIFF
--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -62,6 +62,7 @@ const DefaultMaxUncompressedBatchSize = 16 * 1024 * 1024 // 16 MB
 type ArbitrumChainParams struct {
 	EnableArbOS               bool
 	AllowDebugPrecompiles     bool
+	DisableOffchainArbOwner   bool
 	DataAvailabilityCommittee bool
 	InitialArbOSVersion       uint64
 	InitialChainOwner         common.Address
@@ -95,6 +96,10 @@ func (c *ChainConfig) MaxInitCodeSize() uint64 {
 
 func (c *ChainConfig) DebugMode() bool {
 	return c.ArbitrumChainParams.AllowDebugPrecompiles
+}
+
+func (c *ChainConfig) DisableOffchainArbOwner() bool {
+	return c.ArbitrumChainParams.DisableOffchainArbOwner
 }
 
 func (c *ChainConfig) MaxUncompressedBatchSize() uint64 {


### PR DESCRIPTION
- Add `DisableOffchainArbOwner` bool field to `ArbitrumChainParams`
- Add `DisableOffchainArbOwner()` accessor method on `*ChainConfig`
- Defaults to `false` (no behavior change for existing chains)

pulled in by https://github.com/OffchainLabs/nitro/pull/4591
part of [NIT-4744](https://linear.app/offchain-labs/issue/NIT-4744/add-a-flag-to-disable-arbowner-unless-in-isexecuteonchain-mode)