### PR TITLE
arbitrum: Add FilterSetID to FilteredAddressRecord

### DIFF
--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -43,8 +43,13 @@ type FilterReason struct {
 }
 
 // lint:require-exhaustive-initialization
-type FilteredAddressRecord struct {
-	FilterSetID string         `json:"filterSetId"`
-	Address     common.Address `json:"address"`
+type FilteredAddressWithReason struct {
+	Address common.Address `json:"address"`
 	FilterReason
+}
+
+// lint:require-exhaustive-initialization
+type FilteredAddressRecord struct {
+	FilterSetID string `json:"filterSetId"`
+	FilteredAddressWithReason
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"github.com/google/uuid"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -44,6 +46,7 @@ type FilterReason struct {
 
 // lint:require-exhaustive-initialization
 type FilteredAddressRecord struct {
-	Address common.Address `json:"address"`
+	FilterSetID uuid.UUID      `json:"filterSetId"`
+	Address     common.Address `json:"address"`
 	FilterReason
 }

--- a/arbitrum/filter/filter_report.go
+++ b/arbitrum/filter/filter_report.go
@@ -1,8 +1,6 @@
 package filter
 
 import (
-	"github.com/google/uuid"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -46,7 +44,7 @@ type FilterReason struct {
 
 // lint:require-exhaustive-initialization
 type FilteredAddressRecord struct {
-	FilterSetID uuid.UUID      `json:"filterSetId"`
+	FilterSetID string         `json:"filterSetId"`
 	Address     common.Address `json:"address"`
 	FilterReason
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -29,8 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -237,11 +235,11 @@ func (s *StateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 	return false, nil
 }
 
-func (s *StateDB) FilterSetID() uuid.UUID {
+func (s *StateDB) FilterSetID() string {
 	if s.arbExtraData.addressChecker != nil {
 		return s.arbExtraData.addressChecker.FilterSetID()
 	}
-	return uuid.Nil
+	return ""
 }
 
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -222,9 +222,9 @@ func (s *StateDB) SetAddressChecker(checker AddressChecker) {
 	s.arbExtraData.addressChecker = checker
 }
 
-func (s *StateDB) TouchAddress(record *filter.FilteredAddressRecord) {
+func (s *StateDB) TouchAddress(addr filter.FilteredAddressWithReason) {
 	if s.arbExtraData.addressCheckerState != nil {
-		s.arbExtraData.addressCheckerState.TouchAddress(record)
+		s.arbExtraData.addressCheckerState.TouchAddress(addr)
 	}
 }
 
@@ -233,13 +233,6 @@ func (s *StateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 		return s.arbExtraData.addressCheckerState.IsFiltered()
 	}
 	return false, nil
-}
-
-func (s *StateDB) FilterSetID() string {
-	if s.arbExtraData.addressChecker != nil {
-		return s.arbExtraData.addressChecker.FilterSetID()
-	}
-	return ""
 }
 
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -224,7 +224,7 @@ func (s *StateDB) SetAddressChecker(checker AddressChecker) {
 
 func (s *StateDB) TouchAddress(touched *filter.FilteredAddressWithReason) {
 	if s.arbExtraData.addressCheckerState != nil {
-		s.arbExtraData.addressCheckerState.TouchAddress(*touched)
+		s.arbExtraData.addressCheckerState.TouchAddress(touched)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -222,9 +222,9 @@ func (s *StateDB) SetAddressChecker(checker AddressChecker) {
 	s.arbExtraData.addressChecker = checker
 }
 
-func (s *StateDB) TouchAddress(touched filter.FilteredAddressWithReason) {
+func (s *StateDB) TouchAddress(touched *filter.FilteredAddressWithReason) {
 	if s.arbExtraData.addressCheckerState != nil {
-		s.arbExtraData.addressCheckerState.TouchAddress(touched)
+		s.arbExtraData.addressCheckerState.TouchAddress(*touched)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -233,6 +235,13 @@ func (s *StateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 		return s.arbExtraData.addressCheckerState.IsFiltered()
 	}
 	return false, nil
+}
+
+func (s *StateDB) FilterSetID() uuid.UUID {
+	if s.arbExtraData.addressChecker != nil {
+		return s.arbExtraData.addressChecker.FilterSetID()
+	}
+	return uuid.Nil
 }
 
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -222,9 +222,9 @@ func (s *StateDB) SetAddressChecker(checker AddressChecker) {
 	s.arbExtraData.addressChecker = checker
 }
 
-func (s *StateDB) TouchAddress(addr filter.FilteredAddressWithReason) {
+func (s *StateDB) TouchAddress(touched filter.FilteredAddressWithReason) {
 	if s.arbExtraData.addressCheckerState != nil {
-		s.arbExtraData.addressCheckerState.TouchAddress(addr)
+		s.arbExtraData.addressCheckerState.TouchAddress(touched)
 	}
 }
 

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -27,6 +27,8 @@ import (
 	"runtime"
 	"slices"
 
+	"github.com/google/uuid"
+
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -326,6 +328,9 @@ type AddressCheckerState interface {
 type AddressChecker interface {
 	// NewTxState creates fresh state for a new transaction.
 	NewTxState() AddressCheckerState
+
+	// FilterSetID returns the UUID of the currently loaded filter set.
+	FilterSetID() uuid.UUID
 }
 
 type ArbitrumExtraData struct {

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -313,7 +313,9 @@ var ErrArbTxFilter error = errors.New("internal error")
 // Implementations manage their own synchronization (sync, WaitGroup, channels, etc).
 type AddressCheckerState interface {
 	// TouchAddress records an address access and checks if it should be filtered.
-	TouchAddress(record *filter.FilteredAddressRecord)
+	// The checker is responsible for attaching the filter set ID to produce the
+	// final FilteredAddressRecord.
+	TouchAddress(filter.FilteredAddressWithReason)
 
 	// IsFiltered returns whether any touched address was filtered and the
 	// list of filtered address records collected during the transaction.
@@ -326,9 +328,6 @@ type AddressCheckerState interface {
 type AddressChecker interface {
 	// NewTxState creates fresh state for a new transaction.
 	NewTxState() AddressCheckerState
-
-	// FilterSetID returns the ID of the currently loaded filter set.
-	FilterSetID() string
 }
 
 type ArbitrumExtraData struct {

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -348,7 +348,7 @@ type AddressCheckerState interface {
 	// TouchAddress records an address access and checks if it should be filtered.
 	// The checker is responsible for attaching the filter set ID to produce the
 	// final FilteredAddressRecord.
-	TouchAddress(filter.FilteredAddressWithReason)
+	TouchAddress(*filter.FilteredAddressWithReason)
 
 	// IsFiltered returns whether any touched address was filtered and the
 	// list of filtered address records collected during the transaction.

--- a/core/state/statedb_arbitrum.go
+++ b/core/state/statedb_arbitrum.go
@@ -27,8 +27,6 @@ import (
 	"runtime"
 	"slices"
 
-	"github.com/google/uuid"
-
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -329,8 +327,8 @@ type AddressChecker interface {
 	// NewTxState creates fresh state for a new transaction.
 	NewTxState() AddressCheckerState
 
-	// FilterSetID returns the UUID of the currently loaded filter set.
-	FilterSetID() uuid.UUID
+	// FilterSetID returns the ID of the currently loaded filter set.
+	FilterSetID() string
 }
 
 type ArbitrumExtraData struct {

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -366,8 +366,8 @@ func (s *hookedStateDB) SetAddressChecker(checker AddressChecker) {
 	s.inner.SetAddressChecker(checker)
 }
 
-func (s *hookedStateDB) TouchAddress(addr filter.FilteredAddressWithReason) {
-	s.inner.TouchAddress(addr)
+func (s *hookedStateDB) TouchAddress(touched filter.FilteredAddressWithReason) {
+	s.inner.TouchAddress(touched)
 }
 
 func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -366,16 +366,12 @@ func (s *hookedStateDB) SetAddressChecker(checker AddressChecker) {
 	s.inner.SetAddressChecker(checker)
 }
 
-func (s *hookedStateDB) TouchAddress(record *filter.FilteredAddressRecord) {
-	s.inner.TouchAddress(record)
+func (s *hookedStateDB) TouchAddress(addr filter.FilteredAddressWithReason) {
+	s.inner.TouchAddress(addr)
 }
 
 func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 	return s.inner.IsAddressFiltered()
-}
-
-func (s *hookedStateDB) FilterSetID() string {
-	return s.inner.FilterSetID()
 }
 
 func (s *hookedStateDB) Recording() bool {

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -19,8 +19,6 @@ package state
 import (
 	"math/big"
 
-	"github.com/google/uuid"
-
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -376,7 +374,7 @@ func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecor
 	return s.inner.IsAddressFiltered()
 }
 
-func (s *hookedStateDB) FilterSetID() uuid.UUID {
+func (s *hookedStateDB) FilterSetID() string {
 	return s.inner.FilterSetID()
 }
 

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -19,6 +19,8 @@ package state
 import (
 	"math/big"
 
+	"github.com/google/uuid"
+
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -372,6 +374,10 @@ func (s *hookedStateDB) TouchAddress(record *filter.FilteredAddressRecord) {
 
 func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {
 	return s.inner.IsAddressFiltered()
+}
+
+func (s *hookedStateDB) FilterSetID() uuid.UUID {
+	return s.inner.FilterSetID()
 }
 
 func (s *hookedStateDB) Recording() bool {

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -371,7 +371,7 @@ func (s *hookedStateDB) SetAddressChecker(checker AddressChecker) {
 }
 
 func (s *hookedStateDB) TouchAddress(touched filter.FilteredAddressWithReason) {
-	s.inner.TouchAddress(touched)
+	s.inner.TouchAddress(&touched)
 }
 
 func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -370,8 +370,8 @@ func (s *hookedStateDB) SetAddressChecker(checker AddressChecker) {
 	s.inner.SetAddressChecker(checker)
 }
 
-func (s *hookedStateDB) TouchAddress(touched filter.FilteredAddressWithReason) {
-	s.inner.TouchAddress(&touched)
+func (s *hookedStateDB) TouchAddress(touched *filter.FilteredAddressWithReason) {
+	s.inner.TouchAddress(touched)
 }
 
 func (s *hookedStateDB) IsAddressFiltered() (bool, []filter.FilteredAddressRecord) {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -925,6 +925,7 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 	}
 	beneficiary := scope.Stack.pop()
 	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
+		FilterSetID:  evm.StateDB.FilterSetID(),
 		Address:      beneficiary.Bytes20(),
 		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil},
 	})
@@ -959,6 +960,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 
 	beneficiary := scope.Stack.pop()
 	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
+		FilterSetID:  evm.StateDB.FilterSetID(),
 		Address:      beneficiary.Bytes20(),
 		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil},
 	})

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -924,7 +924,7 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(filter.FilteredAddressWithReason{Address: beneficiary.Bytes20(), FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil}})
+	evm.StateDB.TouchAddress(&filter.FilteredAddressWithReason{Address: beneficiary.Bytes20(), FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil}})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
 	evm.StateDB.SelfDestruct(scope.Contract.Address())
@@ -955,7 +955,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	}
 
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(filter.FilteredAddressWithReason{Address: beneficiary.Bytes20(), FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil}})
+	evm.StateDB.TouchAddress(&filter.FilteredAddressWithReason{Address: beneficiary.Bytes20(), FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil}})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.SubBalance(scope.Contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -924,11 +924,7 @@ func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
-		FilterSetID:  evm.StateDB.FilterSetID(),
-		Address:      beneficiary.Bytes20(),
-		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil},
-	})
+	evm.StateDB.TouchAddress(filter.FilteredAddressWithReason{Address: beneficiary.Bytes20(), FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil}})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
 	evm.StateDB.SelfDestruct(scope.Contract.Address())
@@ -959,11 +955,7 @@ func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, erro
 	}
 
 	beneficiary := scope.Stack.pop()
-	evm.StateDB.TouchAddress(&filter.FilteredAddressRecord{
-		FilterSetID:  evm.StateDB.FilterSetID(),
-		Address:      beneficiary.Bytes20(),
-		FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil},
-	})
+	evm.StateDB.TouchAddress(filter.FilteredAddressWithReason{Address: beneficiary.Bytes20(), FilterReason: filter.FilterReason{Reason: filter.ReasonSelfdestructBeneficiary, EventRuleMatch: nil}})
 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
 	evm.StateDB.SubBalance(scope.Contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -57,7 +57,7 @@ type StateDB interface {
 	ClearTxFilter()
 	IsTxFiltered() bool
 	SetAddressChecker(checker state.AddressChecker)
-	TouchAddress(filter.FilteredAddressWithReason)
+	TouchAddress(*filter.FilteredAddressWithReason)
 	IsAddressFiltered() (bool, []filter.FilteredAddressRecord)
 
 	Recording() bool

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -56,9 +56,8 @@ type StateDB interface {
 	ClearTxFilter()
 	IsTxFiltered() bool
 	SetAddressChecker(checker state.AddressChecker)
-	TouchAddress(record *filter.FilteredAddressRecord)
+	TouchAddress(filter.FilteredAddressWithReason)
 	IsAddressFiltered() (bool, []filter.FilteredAddressRecord)
-	FilterSetID() string
 
 	Recording() bool
 	Deterministic() bool

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -19,8 +19,6 @@ package vm
 import (
 	"math/big"
 
-	"github.com/google/uuid"
-
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -60,7 +58,7 @@ type StateDB interface {
 	SetAddressChecker(checker state.AddressChecker)
 	TouchAddress(record *filter.FilteredAddressRecord)
 	IsAddressFiltered() (bool, []filter.FilteredAddressRecord)
-	FilterSetID() uuid.UUID
+	FilterSetID() string
 
 	Recording() bool
 	Deterministic() bool

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -19,6 +19,8 @@ package vm
 import (
 	"math/big"
 
+	"github.com/google/uuid"
+
 	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -58,6 +60,7 @@ type StateDB interface {
 	SetAddressChecker(checker state.AddressChecker)
 	TouchAddress(record *filter.FilteredAddressRecord)
 	IsAddressFiltered() (bool, []filter.FilteredAddressRecord)
+	FilterSetID() uuid.UUID
 
 	Recording() bool
 	Deterministic() bool

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -286,9 +286,9 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	if txFilterer != nil {
 		txFilterer.Setup(dirtyState)
 
-		dirtyState.TouchAddress(filter.FilteredAddressWithReason{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
+		dirtyState.TouchAddress(&filter.FilteredAddressWithReason{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
 		if call.To != nil {
-			dirtyState.TouchAddress(filter.FilteredAddressWithReason{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
+			dirtyState.TouchAddress(&filter.FilteredAddressWithReason{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
 		}
 	}
 

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -286,9 +286,10 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	if txFilterer != nil {
 		txFilterer.Setup(dirtyState)
 
-		dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
+		filterSetID := dirtyState.FilterSetID()
+		dirtyState.TouchAddress(&filter.FilteredAddressRecord{FilterSetID: filterSetID, Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
 		if call.To != nil {
-			dirtyState.TouchAddress(&filter.FilteredAddressRecord{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
+			dirtyState.TouchAddress(&filter.FilteredAddressRecord{FilterSetID: filterSetID, Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
 		}
 	}
 

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -286,10 +286,9 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	if txFilterer != nil {
 		txFilterer.Setup(dirtyState)
 
-		filterSetID := dirtyState.FilterSetID()
-		dirtyState.TouchAddress(&filter.FilteredAddressRecord{FilterSetID: filterSetID, Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
+		dirtyState.TouchAddress(filter.FilteredAddressWithReason{Address: call.From, FilterReason: filter.FilterReason{Reason: filter.ReasonFrom, EventRuleMatch: nil}})
 		if call.To != nil {
-			dirtyState.TouchAddress(&filter.FilteredAddressRecord{FilterSetID: filterSetID, Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
+			dirtyState.TouchAddress(filter.FilteredAddressWithReason{Address: *call.To, FilterReason: filter.FilterReason{Reason: filter.ReasonTo, EventRuleMatch: nil}})
 		}
 	}
 


### PR DESCRIPTION
Part of NIT-4780
Waits https://github.com/OffchainLabs/nitro/pull/4557
Pulled in by https://github.com/OffchainLabs/nitro/pull/4626

Add FilterSetID field to FilteredAddressRecord and expose it through the AddressChecker and StateDB interfaces so callers can stamp each record with the active filter set id.  