### PR TITLE
rpc: support wrapped errors and code-based Is for jsonError

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -126,12 +126,12 @@ func errorMessage(err error) *jsonrpcMessage {
 		Code:    ErrcodeDefault,
 		Message: err.Error(),
 	}}
-	ec, ok := err.(Error)
-	if ok {
+	var ec Error
+	if errors.As(err, &ec) {
 		msg.Error.Code = ec.ErrorCode()
 	}
-	de, ok := err.(DataError)
-	if ok {
+	var de DataError
+	if errors.As(err, &de) {
 		msg.Error.Data = de.ErrorData()
 	}
 	return msg
@@ -156,6 +156,19 @@ func (err *jsonError) ErrorCode() int {
 
 func (err *jsonError) ErrorData() interface{} {
 	return err.Data
+}
+
+// Is reports whether target carries the same JSON-RPC error code as err.
+// This allows errors.Is(receivedErr, sentinel) to work on the client side
+// when receivedErr is a jsonError reconstructed from the wire and sentinel
+// is any error that exposes an ErrorCode() int method.
+func (err *jsonError) Is(target error) bool {
+	type errorCoder interface{ ErrorCode() int }
+	t, ok := target.(errorCoder)
+	if !ok {
+		return false
+	}
+	return err.Code == t.ErrorCode()
 }
 
 // Conn is a subset of the methods of net.Conn which are sufficient for ServerCodec.


### PR DESCRIPTION
1. `errorMessage` previously cast err directly to `rpc.Error`/`DataError`, which missed errors wrapped with `fmt.Errorf("%w", ...)`. Switch to `errors.As` so the code and data are extracted correctly from wrapped errors.
2. Add `(*jsonError).Is` so that `errors.Is(receivedErr, sentinel)` works on the client side when `receivedErr` is a `jsonError` reconstructed from the wire. Matching is by error code: if the sentinel implements `ErrorCode() int`, the codes are compared. This avoids the need for string-based error reconstruction in callers.

---

pulled in by https://github.com/OffchainLabs/nitro/pull/4629