### PR TITLE
port: Deprecate Genesis.Config. Add getter for cached deserializing instead

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -55,7 +55,8 @@ type GenesisAlloc = types.GenesisAlloc
 // Genesis specifies the header fields, state of a genesis block. It also defines hard
 // fork switch-over blocks through the chain configuration.
 type Genesis struct {
-	Config     *params.ChainConfig `json:"config"`
+	// Deprecated: for Arbitrum chains, use SerializedChainConfig instead.
+	Config     *params.ChainConfig `json:"config,omitempty"`
 	Nonce      uint64              `json:"nonce"`
 	Timestamp  uint64              `json:"timestamp"`
 	ExtraData  []byte              `json:"extraData"`
@@ -75,7 +76,21 @@ type Genesis struct {
 	BlobGasUsed   *uint64     `json:"blobGasUsed"`   // EIP-4844
 
 	// Arbitrum
-	ArbOSInit *params.ArbOSInit `json:"arbOSInit,omitempty"`
+	SerializedChainConfig string              `json:"serializedChainConfig,omitempty"`
+	deserializedConfig    *params.ChainConfig // cached deserialized chain config
+	ArbOSInit             *params.ArbOSInit   `json:"arbOSInit,omitempty"`
+}
+
+// GetConfig returns the chain configuration object, corresponding to the g.SerializedChainConfig field.
+func (g *Genesis) GetConfig() (*params.ChainConfig, error) {
+	if g.deserializedConfig == nil {
+		var c params.ChainConfig
+		if err := json.Unmarshal([]byte(g.SerializedChainConfig), &c); err != nil {
+			return nil, fmt.Errorf("failed to deserialize chain config: %w", err)
+		}
+		g.deserializedConfig = &c
+	}
+	return g.deserializedConfig, nil
 }
 
 // copy copies the genesis.
@@ -86,6 +101,7 @@ func (g *Genesis) copy() *Genesis {
 			conf := *g.Config
 			cpy.Config = &conf
 		}
+		cpy.deserializedConfig = nil
 		return &cpy
 	}
 	return nil

--- a/params/config.go
+++ b/params/config.go
@@ -430,7 +430,8 @@ var NetworkNames = map[string]string{
 // Arbitrum
 // ArbOSInit defines some initialization values for ArbOS state.
 type ArbOSInit struct {
-	NativeTokenSupplyManagementEnabled bool `json:"nativeTokenSupplyManagementEnabled"`
+	NativeTokenSupplyManagementEnabled bool     `json:"nativeTokenSupplyManagementEnabled"`
+	InitialL1BaseFee                   *big.Int `json:"initialL1BaseFee"`
 }
 
 // ChainConfig is the core config which determines the blockchain settings.


### PR DESCRIPTION
Port: https://github.com/OffchainLabs/go-ethereum/pull/618
Port: https://github.com/OffchainLabs/go-ethereum/pull/621

pulled in by https://github.com/OffchainLabs/nitro/pull/4637
part of NIT-4800