### PR TITLE
core, params: add Arbos60 (Elara) precompile gating

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -218,6 +218,8 @@ func activePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 		return PrecompiledContractsStartingFromArbOS60
 	case rules.IsDia:
 		return PrecompiledContractsStartingFromArbOS50
+	case rules.IsGreaterEqual41:
+		return PrecompiledContractsStartingFromArbOS41
 	case rules.IsStylus:
 		return PrecompiledContractsStartingFromArbOS30
 	case rules.IsArbitrum:
@@ -253,6 +255,8 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 		return PrecompiledAddressesStartingFromArbOS60
 	case rules.IsDia:
 		return PrecompiledAddressesStartingFromArbOS50
+	case rules.IsGreaterEqual41:
+		return PrecompiledAddressesStartingFromArbOS41
 	case rules.IsStylus:
 		return PrecompiledAddressesStartingFromArbOS30
 	case rules.IsArbitrum:

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -214,6 +214,8 @@ func init() {
 
 func activePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 	switch {
+	case rules.IsElara:
+		return PrecompiledContractsStartingFromArbOS60
 	case rules.IsDia:
 		return PrecompiledContractsStartingFromArbOS50
 	case rules.IsStylus:
@@ -247,6 +249,8 @@ func ActivePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 // ActivePrecompiles returns the precompile addresses enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsElara:
+		return PrecompiledAddressesStartingFromArbOS60
 	case rules.IsDia:
 		return PrecompiledAddressesStartingFromArbOS50
 	case rules.IsStylus:

--- a/core/vm/contracts_arbitrum.go
+++ b/core/vm/contracts_arbitrum.go
@@ -23,6 +23,8 @@ var (
 	PrecompiledAddressesBeforeArbOS30       []common.Address
 	PrecompiledContractsStartingFromArbOS30 = make(map[common.Address]PrecompiledContract)
 	PrecompiledAddressesStartingFromArbOS30 []common.Address
+	PrecompiledContractsStartingFromArbOS41 = make(map[common.Address]PrecompiledContract)
+	PrecompiledAddressesStartingFromArbOS41 []common.Address
 	PrecompiledContractsStartingFromArbOS50 = make(map[common.Address]PrecompiledContract)
 	PrecompiledAddressesStartingFromArbOS50 []common.Address
 	PrecompiledContractsStartingFromArbOS60 = make(map[common.Address]PrecompiledContract)

--- a/core/vm/contracts_arbitrum.go
+++ b/core/vm/contracts_arbitrum.go
@@ -25,4 +25,6 @@ var (
 	PrecompiledAddressesStartingFromArbOS30 []common.Address
 	PrecompiledContractsStartingFromArbOS50 = make(map[common.Address]PrecompiledContract)
 	PrecompiledAddressesStartingFromArbOS50 []common.Address
+	PrecompiledContractsStartingFromArbOS60 = make(map[common.Address]PrecompiledContract)
+	PrecompiledAddressesStartingFromArbOS60 []common.Address
 )

--- a/params/config.go
+++ b/params/config.go
@@ -1435,7 +1435,7 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	IsArbitrum, IsStylus, IsDia                             bool
+	IsArbitrum, IsStylus, IsDia, IsElara                    bool
 	ChainID                                                 *big.Int
 	ArbOSVersion                                            uint64
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
@@ -1459,6 +1459,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 		IsArbitrum:       c.IsArbitrum(),
 		IsStylus:         c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Stylus,
 		IsDia:            c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Dia,
+		IsElara:          c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Elara,
 		ChainID:          new(big.Int).Set(chainID),
 		ArbOSVersion:     currentArbosVersion,
 		IsHomestead:      c.IsHomestead(num),

--- a/params/config.go
+++ b/params/config.go
@@ -1435,7 +1435,7 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	IsArbitrum, IsStylus, IsDia, IsElara                    bool
+	IsArbitrum, IsStylus, IsGreaterEqual41, IsDia, IsElara  bool
 	ChainID                                                 *big.Int
 	ArbOSVersion                                            uint64
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
@@ -1458,6 +1458,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 	return Rules{
 		IsArbitrum:       c.IsArbitrum(),
 		IsStylus:         c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Stylus,
+		IsGreaterEqual41: c.IsArbitrum() && currentArbosVersion >= ArbosVersion_41,
 		IsDia:            c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Dia,
 		IsElara:          c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Elara,
 		ChainID:          new(big.Int).Set(chainID),

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -49,6 +49,7 @@ const ArbosVersion_StylusChargingFixes = ArbosVersion_32
 const MaxArbosVersionSupported = ArbosVersion_51
 const MaxDebugArbosVersionSupported = ArbosVersion_60
 const ArbosVersion_Dia = ArbosVersion_50
+const ArbosVersion_Elara = ArbosVersion_60
 
 const ArbosVersion_SingleGasConstraintsVersion = ArbosVersion_50
 const ArbosVersion_MultiConstraintFix = ArbosVersion_51


### PR DESCRIPTION
Pulled in by https://github.com/OffchainLabs/nitro/pull/4645
Part of NIT-4785

This PR adds `ArbOS Elara` to activated precompile rules.