### PR TITLE
arbitrum: Return filtered address records from TxFilterer.CheckFiltered

### DIFF
--- a/core/arbitrum_hooks.go
+++ b/core/arbitrum_hooks.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/arbitrum/filter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -58,7 +59,7 @@ type TxFilterer interface {
 	// TouchAddresses marks sender, recipient, aliased, and retryable addresses for filtering.
 	TouchAddresses(statedb *state.StateDB, tx *types.Transaction, sender common.Address)
 	// CheckFiltered applies event filtering and returns state.ErrArbTxFilter if filtered.
-	CheckFiltered(statedb *state.StateDB) error
+	CheckFiltered(statedb *state.StateDB) ([]filter.FilteredAddressRecord, error)
 }
 
 type NodeInterfaceBackendAPI interface {

--- a/core/arbitrum_hooks.go
+++ b/core/arbitrum_hooks.go
@@ -58,7 +58,10 @@ type TxFilterer interface {
 	Setup(statedb *state.StateDB)
 	// TouchAddresses marks sender, recipient, aliased, and retryable addresses for filtering.
 	TouchAddresses(statedb *state.StateDB, tx *types.Transaction, sender common.Address)
-	// CheckFiltered applies event filtering and returns state.ErrArbTxFilter if filtered.
+	// CheckFiltered applies event filtering and returns any filtered address records.
+	// If the transaction is filtered, it returns the matching records together with
+	// state.ErrArbTxFilter. On success, callers should expect no filtering error and
+	// no filtered address records.
 	CheckFiltered(statedb *state.StateDB) ([]filter.FilteredAddressRecord, error)
 }
 

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -51,6 +51,8 @@ type Options struct {
 	BlockOverrides   *override.BlockOverrides // Block overrides to apply during the estimation
 	Backend          core.NodeInterfaceBackendAPI
 	RunScheduledTxes func(context.Context, core.NodeInterfaceBackendAPI, *state.StateDB, *types.Header, vm.BlockContext, *core.MessageRunContext, *core.ExecutionResult, core.TxFilterer) (*core.ExecutionResult, error)
+	// ReportFilteredTx, if non-nil, is invoked when address filtering rejects the tx.
+	ReportFilteredTx func(context.Context, []filter.FilteredAddressRecord)
 
 	ErrorRatio float64 // Allowed overestimation ratio for faster estimation termination
 }
@@ -228,7 +230,7 @@ func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit ui
 
 	// Execute the call and separate execution faults caused by a lack of gas or
 	// other non-fixable conditions
-	result, _, err := run(ctx, call, opts)
+	result, err := run(ctx, call, opts)
 	if err != nil {
 		if errors.Is(err, core.ErrIntrinsicGas) {
 			return true, nil, nil // Special case, raise gas limit
@@ -242,14 +244,13 @@ func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit ui
 }
 
 // Public API for gas estimation. Separated to simplify upstream merges.
-// When address filtering trips, the returned records describe the filtered addresses.
-func Run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, []filter.FilteredAddressRecord, error) {
+func Run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, error) {
 	return run(ctx, call, opts)
 }
 
 // run assembles the EVM as defined by the consensus rules and runs the requested
 // call invocation.
-func run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, []filter.FilteredAddressRecord, error) {
+func run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, error) {
 	// Assemble the call and the call context
 	var (
 		evmContext = core.NewEVMBlockContext(opts.Header, opts.Chain, nil)
@@ -257,7 +258,7 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	)
 	if opts.BlockOverrides != nil {
 		if err := opts.BlockOverrides.Apply(&evmContext); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 	// Lower the basefee to 0 to avoid breaking EVM
@@ -279,7 +280,7 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	var res *core.ExecutionResult
 	call, res, err := core.InterceptRPCMessage(call, ctx, dirtyState, opts.Header, opts.Backend, &evmContext)
 	if err != nil || res != nil {
-		return res, nil, err
+		return res, err
 	}
 
 	// Arbitrum: set up address filtering
@@ -301,28 +302,28 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	// Execute the call, returning a wrapped error or the result
 	result, err := core.ApplyMessage(evm, call, new(core.GasPool).AddGas(math.MaxUint64))
 	if vmerr := dirtyState.Error(); vmerr != nil {
-		return nil, nil, vmerr
+		return nil, vmerr
 	}
 	if err != nil {
-		return result, nil, fmt.Errorf("failed with %d gas: %w", call.GasLimit, err)
+		return result, fmt.Errorf("failed with %d gas: %w", call.GasLimit, err)
 	}
 
 	// Arbitrum: a tx can schedule another (see retryables)
 	result, err = opts.RunScheduledTxes(ctx, opts.Backend, dirtyState, opts.Header, evmContext, call.TxRunContext, result, txFilterer)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Arbitrum: check address filtering result
 	if txFilterer != nil {
 		records, err := txFilterer.CheckFiltered(dirtyState)
 		if err != nil {
-			if errors.Is(err, state.ErrArbTxFilter) {
-				return nil, records, err
+			if errors.Is(err, state.ErrArbTxFilter) && opts.ReportFilteredTx != nil {
+				opts.ReportFilteredTx(ctx, records)
 			}
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return result, nil, nil
+	return result, nil
 }

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -228,7 +228,7 @@ func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit ui
 
 	// Execute the call and separate execution faults caused by a lack of gas or
 	// other non-fixable conditions
-	result, err := run(ctx, call, opts)
+	result, _, err := run(ctx, call, opts)
 	if err != nil {
 		if errors.Is(err, core.ErrIntrinsicGas) {
 			return true, nil, nil // Special case, raise gas limit
@@ -242,13 +242,14 @@ func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit ui
 }
 
 // Public API for gas estimation. Separated to simplify upstream merges.
-func Run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, error) {
+// When address filtering trips, the returned records describe the filtered addresses.
+func Run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, []filter.FilteredAddressRecord, error) {
 	return run(ctx, call, opts)
 }
 
 // run assembles the EVM as defined by the consensus rules and runs the requested
 // call invocation.
-func run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, error) {
+func run(ctx context.Context, call *core.Message, opts *Options) (*core.ExecutionResult, []filter.FilteredAddressRecord, error) {
 	// Assemble the call and the call context
 	var (
 		evmContext = core.NewEVMBlockContext(opts.Header, opts.Chain, nil)
@@ -256,7 +257,7 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	)
 	if opts.BlockOverrides != nil {
 		if err := opts.BlockOverrides.Apply(&evmContext); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	// Lower the basefee to 0 to avoid breaking EVM
@@ -278,7 +279,7 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	var res *core.ExecutionResult
 	call, res, err := core.InterceptRPCMessage(call, ctx, dirtyState, opts.Header, opts.Backend, &evmContext)
 	if err != nil || res != nil {
-		return res, err
+		return res, nil, err
 	}
 
 	// Arbitrum: set up address filtering
@@ -300,24 +301,28 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 	// Execute the call, returning a wrapped error or the result
 	result, err := core.ApplyMessage(evm, call, new(core.GasPool).AddGas(math.MaxUint64))
 	if vmerr := dirtyState.Error(); vmerr != nil {
-		return nil, vmerr
+		return nil, nil, vmerr
 	}
 	if err != nil {
-		return result, fmt.Errorf("failed with %d gas: %w", call.GasLimit, err)
+		return result, nil, fmt.Errorf("failed with %d gas: %w", call.GasLimit, err)
 	}
 
 	// Arbitrum: a tx can schedule another (see retryables)
 	result, err = opts.RunScheduledTxes(ctx, opts.Backend, dirtyState, opts.Header, evmContext, call.TxRunContext, result, txFilterer)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Arbitrum: check address filtering result
 	if txFilterer != nil {
-		if err := txFilterer.CheckFiltered(dirtyState); err != nil {
-			return nil, err
+		records, err := txFilterer.CheckFiltered(dirtyState)
+		if err != nil {
+			if errors.Is(err, state.ErrArbTxFilter) {
+				return nil, records, err
+			}
+			return nil, nil, err
 		}
 	}
 
-	return result, nil
+	return result, nil, nil
 }


### PR DESCRIPTION
Part of [NIT-4645](https://linear.app/offchain-labs/issue/NIT-4645)
Pulled in by https://github.com/OffchainLabs/nitro/pull/4653

Return filtered address records from TxFilterer.CheckFiltered so nitro callers (TxPreChecker) can build a filtered-tx report without re-querying the statedb. gasestimator.Run propagates records only on the ErrArbTxFilter branch.