### PR TITLE
arbitrum: fix ArbitrumUnsignedTx marshaling/unmarshaling with maxFeePerGas

### DIFF
--- a/core/types/transaction_arbitrum_test.go
+++ b/core/types/transaction_arbitrum_test.go
@@ -16,7 +16,80 @@
 
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Decoder rules for ArbitrumUnsignedTx (0x65) JSON.
+func TestArbitrumUnsignedTxJSONDecode(t *testing.T) {
+	t.Parallel()
+	const (
+		mainnetFee  = "0x3b9aca00"
+		mainnetHash = "0x5618044241dade84af6c41b7d84496dc9823700f98b79751e257608dac570f6b"
+	)
+	mainnet := map[string]string{
+		"type":    "0x65",
+		"chainId": "0xa4b1",
+		"from":    "0x5d3919f12bcc35c26eee5f8226a9bee90c257ccc",
+		"to":      "0x0000000000000000000000000000000000000da0",
+		"nonce":   "0x0",
+		"gas":     "0x186a0",
+		"value":   "0x683cf676a5cc88b3b50",
+		"input":   "0x",
+	}
+	for _, tc := range []struct {
+		name                   string
+		gasPrice, maxFeePerGas string
+		wantErr, wantFeeCap    string
+		checkMainnetHash       bool
+	}{
+		{name: "mainnet legacy shape", gasPrice: mainnetFee, wantFeeCap: mainnetFee, checkMainnetHash: true},
+		{name: "maxFeePerGas only", maxFeePerGas: mainnetFee, wantFeeCap: mainnetFee},
+		{name: "both equal", gasPrice: mainnetFee, maxFeePerGas: mainnetFee, wantFeeCap: mainnetFee},
+		{name: "precedence gasPrice=0", gasPrice: "0x0", maxFeePerGas: "0x2", wantFeeCap: "0x2"},
+		{name: "both zero", gasPrice: "0x0", maxFeePerGas: "0x0", wantFeeCap: "0x0"},
+		{name: "conflict", gasPrice: "0x1", maxFeePerGas: "0x2", wantErr: "conflicting gasPrice and maxFeePerGas"},
+		{name: "gasPrice=0 alone", gasPrice: "0x0", wantErr: "(or 'gasPrice')"},
+		{name: "missing both", wantErr: "(or 'gasPrice')"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := maps.Clone(mainnet)
+			if tc.gasPrice != "" {
+				m["gasPrice"] = tc.gasPrice
+			}
+			if tc.maxFeePerGas != "" {
+				m["maxFeePerGas"] = tc.maxFeePerGas
+			}
+			data, err := json.Marshal(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var tx Transaction
+			err = json.Unmarshal(data, &tx)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err: got %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got := fmt.Sprintf("0x%x", tx.GasFeeCap()); got != tc.wantFeeCap {
+				t.Fatalf("GasFeeCap: got %s, want %s", got, tc.wantFeeCap)
+			}
+			if tc.checkMainnetHash && tx.Hash() != common.HexToHash(mainnetHash) {
+				t.Fatalf("hash: got %s, want %s", tx.Hash(), mainnetHash)
+			}
+		})
+	}
+}
 
 func TestTxCalldataUnitsCache(t *testing.T) {
 	tx := &Transaction{}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -549,8 +549,20 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.Nonce == nil {
 			return errors.New("missing required field 'nonce' in transaction")
 		}
-		if dec.MaxFeePerGas == nil {
-			return errors.New("missing required field 'maxFeePerGas' for txdata")
+		// Legacy RPC encoders emit gasPrice only for 0x65; accept as fallback
+		// for backward compat. gasPrice==0 is treated as unset (MarshalJSON
+		// emits 0 as a default).
+		feeCap := dec.MaxFeePerGas
+		if dec.MaxFeePerGas != nil && dec.GasPrice != nil {
+			gp := (*big.Int)(dec.GasPrice)
+			if gp.Sign() > 0 && gp.Cmp((*big.Int)(dec.MaxFeePerGas)) != 0 {
+				return errors.New("conflicting gasPrice and maxFeePerGas for txdata")
+			}
+		} else if dec.GasPrice != nil && (*big.Int)(dec.GasPrice).Sign() > 0 {
+			feeCap = dec.GasPrice
+		}
+		if feeCap == nil {
+			return errors.New("missing required field 'maxFeePerGas' (or 'gasPrice') for txdata")
 		}
 		if dec.Gas == nil {
 			return errors.New("missing required field 'gas' in txdata")
@@ -565,7 +577,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			ChainId:   (*big.Int)(dec.ChainID),
 			From:      *dec.From,
 			Nonce:     uint64(*dec.Nonce),
-			GasFeeCap: (*big.Int)(dec.MaxFeePerGas),
+			GasFeeCap: (*big.Int)(feeCap),
 			Gas:       uint64(*dec.Gas),
 			To:        dec.To,
 			Value:     (*big.Int)(dec.Value),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1297,6 +1297,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.GasFeeCap = (*hexutil.Big)(inner.GasFeeCap)
 		result.ChainID = (*hexutil.Big)(inner.ChainId)
 	case *types.ArbitrumUnsignedTx:
+		result.GasFeeCap = (*hexutil.Big)(inner.GasFeeCap)
 		result.ChainID = (*hexutil.Big)(inner.ChainId)
 	}
 	return result

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -119,6 +119,56 @@ func TestTransactionBlobTx(t *testing.T) {
 	testTransactionMarshal(t, tests, &config)
 }
 
+func TestArbitrumFeeTxRPCJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	to := common.HexToAddress("0xda0")
+	cfg := *params.TestChainConfig
+	cfg.ArbitrumChainParams = params.ArbitrumChainParams{EnableArbOS: true}
+	feeCap := big.NewInt(1e9)
+	for _, tc := range []struct {
+		name string
+		data types.TxData
+	}{
+		{"ArbitrumUnsignedTx", &types.ArbitrumUnsignedTx{
+			ChainId: big.NewInt(0xa4b1), From: common.Address{0x5d}, GasFeeCap: feeCap,
+			Gas: 1, To: &to, Value: big.NewInt(0), Data: []byte{},
+		}},
+		{"ArbitrumContractTx", &types.ArbitrumContractTx{
+			ChainId: big.NewInt(0xa4b1), From: common.Address{0x66}, GasFeeCap: feeCap,
+			Gas: 1, To: &to, Value: big.NewInt(0), Data: []byte{},
+		}},
+		{"ArbitrumRetryTx", &types.ArbitrumRetryTx{
+			ChainId: big.NewInt(0xa4b1), From: common.Address{0x68}, GasFeeCap: feeCap,
+			Gas: 1, To: &to, Value: big.NewInt(0), Data: []byte{},
+			MaxRefund: big.NewInt(0), SubmissionFeeRefund: big.NewInt(0),
+		}},
+		{"ArbitrumSubmitRetryableTx", &types.ArbitrumSubmitRetryableTx{
+			ChainId: big.NewInt(0xa4b1), From: common.Address{0x69}, GasFeeCap: feeCap,
+			Gas: 1, RetryTo: &to, RetryValue: big.NewInt(0), RetryData: []byte{},
+			L1BaseFee: big.NewInt(0), DepositValue: big.NewInt(0), MaxSubmissionFee: big.NewInt(0),
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := types.NewTx(tc.data)
+			rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, &cfg, params.MaxArbosVersionSupported)
+			if rpcTx.GasFeeCap == nil {
+				t.Fatal("GasFeeCap (maxFeePerGas) not set: producer regression")
+			}
+			data, err := json.Marshal(rpcTx)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded types.Transaction
+			if err := decoded.UnmarshalJSON(data); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if decoded.Hash() != tx.Hash() {
+				t.Fatalf("hash: got %s, want %s", decoded.Hash(), tx.Hash())
+			}
+		})
+	}
+}
+
 type txData struct {
 	Tx   types.TxData
 	Want string


### PR DESCRIPTION
Part of NIT-4838
Pulled in by https://github.com/OffchainLabs/nitro/pull/4670

  Fixed both ends to align producer <-> consumer:  
  - **Producer** (`internal/ethapi/api.go`): `newRPCTransaction` now emits `GasFeeCap` (→ `maxFeePerGas`) for      
  `*ArbitrumUnsignedTx`. Was setting only `ChainID`.
  - **Decoder** (`core/types/transaction_marshalling.go`): accepts `gasPrice` as fallback when `maxFeePerGas`      
  absent for 0x65. Rejects conflict when both non-zero and unequal. Treats `gasPrice=0` as unset (MarshalJSON      
  default).
                                                                                                                   
  Both sides needed: producer fix unblocks new output; decoder fix handles historical/external data already on     
  chain.
                                                                                                                   
  Scope: 0x65 only. Other Arbitrum fee tx types (0x66/0x68/0x69) always emitted `maxFeePerGas` correctly.  