### PR TITLE
core: Log / UX improvements for node operators

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -303,9 +303,10 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 
 		// we expect the first number to come in to be [from]. Therefore, setting
 		// nextNum to from means that the queue gap-evaluation will work correctly
-		nextNum     = from
-		queue       = prque.New[int64, *blockTxHashes](nil)
-		blocks, txs = 0, 0 // for stats reporting
+		nextNum          = from
+		queue            = prque.New[int64, *blockTxHashes](nil)
+		blocks, txs      = 0, 0 // for stats reporting
+		loggedFirstBanner = false
 	)
 	// Otherwise spin up the concurrent iterator and unindexer
 	for delivery := range hashesCh {
@@ -340,7 +341,12 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 			}
 			// If we've spent too much time already, notify the user of what we're doing
 			if time.Since(logged) > 8*time.Second {
-				log.Info("Unindexing transactions", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+				if !loggedFirstBanner {
+					log.Info("Unindexing transactions — this is normal maintenance and does not indicate data loss", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+					loggedFirstBanner = true
+				} else {
+					log.Debug("Unindexing transactions", "blocks", blocks, "txs", txs, "total", to-from, "elapsed", common.PrettyDuration(time.Since(start)))
+				}
 				logged = time.Now()
 			}
 		}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -303,9 +303,9 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 
 		// we expect the first number to come in to be [from]. Therefore, setting
 		// nextNum to from means that the queue gap-evaluation will work correctly
-		nextNum          = from
-		queue            = prque.New[int64, *blockTxHashes](nil)
-		blocks, txs      = 0, 0 // for stats reporting
+		nextNum           = from
+		queue             = prque.New[int64, *blockTxHashes](nil)
+		blocks, txs       = 0, 0 // for stats reporting
 		loggedFirstBanner = false
 	)
 	// Otherwise spin up the concurrent iterator and unindexer

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -727,13 +727,19 @@ func printChainMetadata(db ethdb.KeyValueStore) {
 func ReadChainMetadata(db ethdb.KeyValueStore) [][]string {
 	pp := func(val *uint64) string {
 		if val == nil {
-			return "not set (new or uninitialized database)"
+			return "<nil>"
 		}
 		return fmt.Sprintf("%d (%#x)", *val, *val)
 	}
 
+	dbVersion := ReadDatabaseVersion(db)
+	dbVersionStr := "not set (new or uninitialized database)"
+	if dbVersion != nil {
+		dbVersionStr = fmt.Sprintf("%d (%#x)", *dbVersion, *dbVersion)
+	}
+
 	data := [][]string{
-		{"databaseVersion", pp(ReadDatabaseVersion(db))},
+		{"databaseVersion", dbVersionStr},
 		{"headBlockHash", fmt.Sprintf("%v", ReadHeadBlockHash(db))},
 		{"headFastBlockHash", fmt.Sprintf("%v", ReadHeadFastBlockHash(db))},
 		{"headHeaderHash", fmt.Sprintf("%v", ReadHeadHeaderHash(db))},

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -727,7 +727,7 @@ func printChainMetadata(db ethdb.KeyValueStore) {
 func ReadChainMetadata(db ethdb.KeyValueStore) [][]string {
 	pp := func(val *uint64) string {
 		if val == nil {
-			return "<nil>"
+			return "not set (new or uninitialized database)"
 		}
 		return fmt.Sprintf("%d (%#x)", *val, *val)
 	}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -74,7 +74,7 @@ type Config struct {
 //   - iterate the database, delete all other state entries which
 //     don't belong to the target state and the genesis state
 //
-// It can take several hours(around 2 hours for mainnet) to finish
+// It can take several days for large databases (e.g. Arbitrum One) to finish
 // the whole pruning work. It's recommended to run this offline tool
 // periodically in order to release the disk usage and improve the
 // disk read performance to some extent.


### PR DESCRIPTION
## Summary

Log and error message improvements for node operator UX, companion to [nitro#4607](https://github.com/OffchainLabs/nitro/pull/4607).

pulled in by https://github.com/OffchainLabs/nitro/pull/4607

## Changes

- `core/rawdb/database.go`: `databaseVersion` now shows "not set (new or uninitialized database)" instead of cryptic `<nil>`. Other nil metadata fields keep `<nil>` to avoid misleading diagnostic output.
- `core/rawdb/chain_iterator.go`: "Unindexing transactions" first log explains it is normal maintenance; subsequent periodic logs downgraded to DEBUG to avoid log spam (12+ hour runs previously flooded INFO).
- `core/state/pruner/pruner.go`: Updated comment from "around 2 hours for mainnet" to "several days for large databases (e.g. Arbitrum One)" to match observed user reports.