### PR TITLE
ethapi: set simulateV1 timestampIncrement to 0 for Arbitrum

### DIFF
--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -44,9 +44,7 @@ const (
 	maxSimulateBlocks = 256
 
 	// timestampIncrement is the default increment between block timestamps.
-	// Arbitrum produces a block every 250ms; at second granularity this rounds
-	// down to 0, so consecutive simulated blocks share the same timestamp.
-	timestampIncrement = 0
+	timestampIncrement = 12
 )
 
 // simBlock is a batch of calls to be simulated sequentially.
@@ -397,6 +395,15 @@ func (sim *simulator) activePrecompiles(base *types.Header) vm.PrecompiledContra
 	return vm.ActivePrecompiledContracts(rules)
 }
 
+// timestampIncrementForChain returns zero for Arbitrum because its 250ms block
+// time is below the one-second precision of block timestamps.
+func (sim *simulator) timestampIncrementForChain() uint64 {
+	if sim.chainConfig != nil && sim.chainConfig.IsArbitrum() {
+		return 0
+	}
+	return timestampIncrement
+}
+
 // sanitizeChain checks the chain integrity. Specifically it checks that
 // block numbers and timestamp are strictly increasing, setting default values
 // when necessary. Gaps in block numbers are filled with empty blocks.
@@ -432,7 +439,7 @@ func (sim *simulator) sanitizeChain(blocks []simBlock) ([]simBlock, error) {
 			// Assign block number to the empty blocks.
 			for i := uint64(0); i < gap.Uint64(); i++ {
 				n := new(big.Int).Add(prevNumber, big.NewInt(int64(i+1)))
-				t := prevTimestamp + timestampIncrement
+				t := prevTimestamp + sim.timestampIncrementForChain()
 				b := simBlock{
 					BlockOverrides: &override.BlockOverrides{
 						Number:      (*hexutil.Big)(n),
@@ -448,7 +455,7 @@ func (sim *simulator) sanitizeChain(blocks []simBlock) ([]simBlock, error) {
 		prevNumber = block.BlockOverrides.Number.ToInt()
 		var t uint64
 		if block.BlockOverrides.Time == nil {
-			t = prevTimestamp + timestampIncrement
+			t = prevTimestamp + sim.timestampIncrementForChain()
 			block.BlockOverrides.Time = (*hexutil.Uint64)(&t)
 		} else {
 			t = uint64(*block.BlockOverrides.Time)

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -44,7 +44,9 @@ const (
 	maxSimulateBlocks = 256
 
 	// timestampIncrement is the default increment between block timestamps.
-	timestampIncrement = 12
+	// Arbitrum produces a block every 250ms; at second granularity this rounds
+	// down to 0, so consecutive simulated blocks share the same timestamp.
+	timestampIncrement = 0
 )
 
 // simBlock is a batch of calls to be simulated sequentially.

--- a/internal/ethapi/simulate_test.go
+++ b/internal/ethapi/simulate_test.go
@@ -23,9 +23,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/internal/ethapi/override"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestSimulateSanitizeBlockOrder(t *testing.T) {
+	arbConfig := *params.TestChainConfig
+	arbConfig.ArbitrumChainParams.EnableArbOS = true
+
 	type result struct {
 		number    uint64
 		timestamp uint64
@@ -33,6 +37,7 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 	for i, tc := range []struct {
 		baseNumber    int
 		baseTimestamp uint64
+		chainConfig   *params.ChainConfig
 		blocks        []simBlock
 		expected      []result
 		err           string
@@ -79,8 +84,28 @@ func TestSimulateSanitizeBlockOrder(t *testing.T) {
 			blocks:        []simBlock{{BlockOverrides: &override.BlockOverrides{Number: newInt(11), Time: newUint64(60)}}, {BlockOverrides: &override.BlockOverrides{Number: newInt(13), Time: newUint64(72)}}},
 			expected:      []result{{number: 11, timestamp: 60}, {number: 12, timestamp: 72}, {number: 13, timestamp: 72}},
 		},
+		{
+			baseNumber:    10,
+			baseTimestamp: 50,
+			chainConfig:   &arbConfig,
+			blocks: []simBlock{
+				{},
+				{BlockOverrides: &override.BlockOverrides{Number: newInt(14), Time: newUint64(75)}},
+				{},
+			},
+			expected: []result{
+				{number: 11, timestamp: 50},
+				{number: 12, timestamp: 50},
+				{number: 13, timestamp: 50},
+				{number: 14, timestamp: 75},
+				{number: 15, timestamp: 75},
+			},
+		},
 	} {
-		sim := &simulator{base: &types.Header{Number: big.NewInt(int64(tc.baseNumber)), Time: tc.baseTimestamp}}
+		sim := &simulator{
+			base:        &types.Header{Number: big.NewInt(int64(tc.baseNumber)), Time: tc.baseTimestamp},
+			chainConfig: tc.chainConfig,
+		}
 		res, err := sim.sanitizeChain(tc.blocks)
 		if err != nil {
 			if err.Error() == tc.err {


### PR DESCRIPTION
Arbitrum produces a block every 250ms. At second granularity (geth's uint64 timestamp), 250ms rounds to 0, so consecutive simulated blocks share the same timestamp. The previous default of 12 (Ethereum's L1 block time) was incorrect for Arbitrum L2 simulation.

nitro references this repo as a git submodule; eth_simulateV1's default timestamp increment should reflect Arbitrum's 250ms block time, not Ethereum's 12s.